### PR TITLE
Introduce SaltyRTCBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Possible log types:
 - `[security]` to invite users to upgrade in case of vulnerabilities.
 
 
+### UNRELEASED
+
+- [changed] Introduce `SaltyRTCBuilder`
+
 ### v0.1.0 (2016-09-07)
 
 - Initial release

--- a/src/main/java/org/saltyrtc/client/SaltyRTC.java
+++ b/src/main/java/org/saltyrtc/client/SaltyRTC.java
@@ -40,53 +40,26 @@ public class SaltyRTC {
     private static final Logger LOG = org.slf4j.LoggerFactory.getLogger("SaltyRTC");
 
     // Whether to enable debug mode
-    protected boolean debug = false;
+    private boolean debug = false;
 
     // Reference to signaling class
-    protected Signaling signaling;
+    private Signaling signaling;
 
     // Event registry
     public final SaltyRTC.Events events = new SaltyRTC.Events();
 
-    /**
-     * Create a SaltyRTC instance as initiator.
-     *
-     * @param permanentKey A KeyStore instance containing the permanent key.
-     * @param host The SaltyRTC server host.
-     * @param port The SaltyRTC server port.
-     * @param sslContext The SSL context used to create the encrypted WebSocket connection.
-     */
-    public SaltyRTC(KeyStore permanentKey, String host, int port, SSLContext sslContext) {
-        validateHost(host);
+    // Internal constructor used by SaltyRTCBuilder.
+    // Initialize as initiator without trusted key.
+    SaltyRTC(KeyStore permanentKey, String host, int port, SSLContext sslContext) {
         this.signaling = new InitiatorSignaling(this, host, port, permanentKey, sslContext);
     }
 
-    /**
-     * Create a SaltyRTC instance as responder.
-     *
-     * @param permanentKey A KeyStore instance containing the permanent key.
-     * @param host The SaltyRTC server host.
-     * @param port The SaltyRTC server port.
-     * @throws InvalidKeyException Either the public key or the auth token is invalid.
-     */
-    public SaltyRTC(KeyStore permanentKey, String host, int port, SSLContext sslContext,
-                    byte[] initiatorPublicKey, byte[] authToken)
-                    throws InvalidKeyException {
-        validateHost(host);
+    // Internal constructor used by SaltyRTCBuilder.
+    // Initialize as initiator without trusted key.
+    SaltyRTC(KeyStore permanentKey, String host, int port, SSLContext sslContext,
+                       byte[] initiatorPublicKey, byte[] authToken) throws InvalidKeyException {
         this.signaling = new ResponderSignaling(
                 this, host, port, permanentKey, sslContext, initiatorPublicKey, authToken);
-    }
-
-    /**
-     * Validate the specified host, throw an IllegalArgumentException if it's invalid.
-     */
-    private void validateHost(String host) {
-        if (host.endsWith("/")) {
-            throw new IllegalArgumentException("SaltyRTC host may not end with a slash");
-        }
-        if (host.contains("//")) {
-            throw new IllegalArgumentException("SaltyRTC host should not contain protocol");
-        }
     }
 
     public byte[] getPublicPermanentKey() {

--- a/src/main/java/org/saltyrtc/client/SaltyRTCBuilder.java
+++ b/src/main/java/org/saltyrtc/client/SaltyRTCBuilder.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2016 Threema GmbH / SaltyRTC Contributors
+ *
+ * Licensed under the Apache License, Version 2.0, <see LICENSE-APACHE file>
+ * or the MIT license <see LICENSE-MIT file>, at your option. This file may not be
+ * copied, modified, or distributed except according to those terms.
+ */
+
+package org.saltyrtc.client;
+
+import org.saltyrtc.client.exceptions.InvalidBuilderStateException;
+import org.saltyrtc.client.keystore.KeyStore;
+
+import java.security.InvalidKeyException;
+
+import javax.net.ssl.SSLContext;
+
+/**
+ * Builder class to construct a SaltyRTC instance.
+ */
+public class SaltyRTCBuilder {
+
+    private boolean hasKeyStore = false;
+    private boolean hasConnectionInfo = false;
+    private boolean hasInitiatorInfo = false;
+
+    private KeyStore keyStore;
+    private String host;
+    private Integer port;
+    private SSLContext sslContext;
+
+    private byte[] initiatorPublicKey;
+    private byte[] authToken;
+
+    /**
+     * Validate the specified host, throw an IllegalArgumentException if it's invalid.
+     */
+    private void validateHost(String host) {
+        if (host.endsWith("/")) {
+            throw new IllegalArgumentException("SaltyRTC host may not end with a slash");
+        }
+        if (host.contains("//")) {
+            throw new IllegalArgumentException("SaltyRTC host should not contain protocol");
+        }
+    }
+
+    /**
+     * Assert that a keystore has been set.
+     */
+    private void requireKeyStore() throws InvalidBuilderStateException {
+        if (!this.hasKeyStore) {
+            throw new InvalidBuilderStateException(
+                    "Keys not set yet. Please call .withKeyStore method first.");
+        }
+    }
+
+    /**
+     * Assert that connection info has been set.
+     */
+    private void requireConnectionInfo() throws InvalidBuilderStateException {
+        if (!this.hasConnectionInfo) {
+            throw new InvalidBuilderStateException(
+                    "Connection info not set yet. Please call .connectTo method first.");
+        }
+    }
+
+    /**
+     * Assert that initiator info has been set.
+     */
+    private void requireInitiatorInfo() throws InvalidBuilderStateException {
+        if (!this.hasInitiatorInfo) {
+            throw new InvalidBuilderStateException(
+                    "Initiator info not set yet. Please call .initiatorInfo method first.");
+        }
+    }
+
+    /**
+     * Set SaltyRTC signalling server connection info.
+     *
+     * @param host The SaltyRTC server host.
+     * @param port The SaltyRTC server port.
+     * @param sslContext The SSL context used to create the encrypted WebSocket connection.
+     * @throws IllegalArgumentException Thrown if the host string is invalid.
+     */
+    public SaltyRTCBuilder connectTo(String host, int port, SSLContext sslContext) {
+        validateHost(host);
+        this.host = host;
+        this.port = port;
+        this.sslContext = sslContext;
+        this.hasConnectionInfo = true;
+        return this;
+    }
+
+    /**
+     * Set the key store. This can be either a new `KeyStore` instance, or a saved one if you
+     * intend to use trusted keys.
+     *
+     * @param keyStore The KeyStore instance containing the public and private permanent key to
+     * use.
+     */
+    public SaltyRTCBuilder withKeyStore(KeyStore keyStore) {
+        this.keyStore = keyStore;
+        this.hasKeyStore = true;
+        return this;
+    }
+
+    /**
+     * Set initiator connection info transferred via a secure data channel.
+     * @param initiatorPublicKey The public key of the initiator.
+     * @param authToken The secret auth token.
+     */
+    public SaltyRTCBuilder initiatorInfo(byte[] initiatorPublicKey, byte[] authToken) {
+        this.initiatorPublicKey = initiatorPublicKey;
+        this.authToken = authToken;
+        this.hasInitiatorInfo = true;
+        return this;
+    }
+
+    /**
+     * Return a SaltyRTC instance configured as initiator.
+     *
+     * @throws InvalidBuilderStateException Thrown if key or connection info haven't been set yet.
+     */
+    public SaltyRTC asInitiator() throws InvalidBuilderStateException {
+        this.requireKeyStore();
+        this.requireConnectionInfo();
+        return new SaltyRTC(this.keyStore, this.host, this.port, this.sslContext);
+    }
+
+    /**
+     * Return a SaltyRTC instance configured as responder.
+     *
+     * @throws InvalidBuilderStateException Thrown if key or connection info or initiator info
+     *     haven't been set yet.
+     * @throws InvalidKeyException Thrown if public key or auth token are invalid.
+     */
+    public SaltyRTC asResponder() throws InvalidBuilderStateException, InvalidKeyException {
+        this.requireKeyStore();
+        this.requireConnectionInfo();
+        this.requireInitiatorInfo();
+        return new SaltyRTC(this.keyStore, this.host, this.port, this.sslContext,
+                this.initiatorPublicKey, this.authToken);
+    }
+}

--- a/src/main/java/org/saltyrtc/client/exceptions/InvalidBuilderStateException.java
+++ b/src/main/java/org/saltyrtc/client/exceptions/InvalidBuilderStateException.java
@@ -1,0 +1,23 @@
+package org.saltyrtc.client.exceptions;
+
+/**
+ * Thrown by SaltyRTCBuilder if a method is called when the builder isn't properly initialized
+ * yet.
+ */
+public class InvalidBuilderStateException extends RuntimeException {
+    public InvalidBuilderStateException() {
+        super();
+    }
+
+    public InvalidBuilderStateException(String message) {
+        super(message);
+    }
+
+    public InvalidBuilderStateException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidBuilderStateException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/test/java/org/saltyrtc/client/tests/integration/ConnectionTest.java
+++ b/src/test/java/org/saltyrtc/client/tests/integration/ConnectionTest.java
@@ -12,6 +12,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.saltyrtc.client.SaltyRTC;
+import org.saltyrtc.client.SaltyRTCBuilder;
 import org.saltyrtc.client.events.EventHandler;
 import org.saltyrtc.client.events.SignalingStateChangedEvent;
 import org.saltyrtc.client.keystore.KeyStore;
@@ -48,11 +49,15 @@ public class ConnectionTest {
         final SSLContext sslContext = SSLContextHelper.getSSLContext();
 
         // Create SaltyRTC instances for initiator and responder
-        initiator = new SaltyRTC(
-            new KeyStore(), Config.SALTYRTC_HOST, Config.SALTYRTC_PORT, sslContext);
-        responder = new SaltyRTC(
-            new KeyStore(), Config.SALTYRTC_HOST, Config.SALTYRTC_PORT, sslContext,
-            initiator.getPublicPermanentKey(), initiator.getAuthToken());
+        initiator = new SaltyRTCBuilder()
+                .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT, sslContext)
+                .withKeyStore(new KeyStore())
+                .asInitiator();
+        responder = new SaltyRTCBuilder()
+                .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT, sslContext)
+                .withKeyStore(new KeyStore())
+                .initiatorInfo(initiator.getPublicPermanentKey(), initiator.getAuthToken())
+                .asResponder();
 
         // Enable verbose debug mode
         if (Config.VERBOSE) {


### PR DESCRIPTION
The builder allows us to implement trusted keys and tasks more easily.

Old API:

```java
initiator = new SaltyRTC(
    new KeyStore(), Config.SALTYRTC_HOST, Config.SALTYRTC_PORT, sslContext);
responder = new SaltyRTC(
    new KeyStore(), Config.SALTYRTC_HOST, Config.SALTYRTC_PORT, sslContext,
    initiator.getPublicPermanentKey(), initiator.getAuthToken());
```

New API:

```java
initiator = new SaltyRTCBuilder()
    .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT, sslContext)
    .withKeystore(new KeyStore())
    .asInitiator();
responder = new SaltyRTCBuilder(new KeyStore())
    .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT, sslContext)
    .withKeystore(new KeyStore())
    .initiatorInfo(initiator.getPublicPermanentKey(), initiator.getAuthToken())
    .asResponder();
```

When using trusted keys, instead of setting `.initiatorInfo(...)` we can add a `.withPeerKey(...)` method.

@lgrahl opinions?