### PR TITLE
Fix concurrency bug in CombinedSequence

### DIFF
--- a/src/main/java/org/saltyrtc/client/nonce/CombinedSequence.java
+++ b/src/main/java/org/saltyrtc/client/nonce/CombinedSequence.java
@@ -15,6 +15,8 @@ import java.security.SecureRandom;
 /**
  * The CombinedSequence class handles the overflow checking of the 48 bit combined sequence number
  * (CSN) consisting of the sequence number and the overflow number.
+ *
+ * This class is thread safe.
  */
 public class CombinedSequence {
     public static long SEQUENCE_NUMBER_MAX = 0x100000000L; // 1<<32
@@ -58,12 +60,12 @@ public class CombinedSequence {
     }
 
     /**
-     * Increment the combined sequence number and return reference to itself.
+     * Increment the combined sequence number and return a CombinedSequenceSnapshot.
      *
      * May throw an error if overflow number overflows. This is extremely unlikely and must be
      * treated as a protocol error.
      */
-    public CombinedSequence next() throws OverflowException {
+    public synchronized CombinedSequenceSnapshot next() throws OverflowException {
         if (this.sequenceNumber + 1 >= CombinedSequence.SEQUENCE_NUMBER_MAX) {
             // Sequence number overflow
             this.sequenceNumber = 0;
@@ -76,6 +78,6 @@ public class CombinedSequence {
             // Simply increment the sequence number
             this.sequenceNumber += 1;
         }
-        return this;
+        return new CombinedSequenceSnapshot(this.sequenceNumber, this.overflow);
     }
 }

--- a/src/main/java/org/saltyrtc/client/nonce/CombinedSequenceSnapshot.java
+++ b/src/main/java/org/saltyrtc/client/nonce/CombinedSequenceSnapshot.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016 Threema GmbH / SaltyRTC Contributors
+ *
+ * Licensed under the Apache License, Version 2.0, <see LICENSE-APACHE file>
+ * or the MIT license <see LICENSE-MIT file>, at your option. This file may not be
+ * copied, modified, or distributed except according to those terms.
+ */
+
+package org.saltyrtc.client.nonce;
+
+/**
+ * An immutable snapshot of a combined sequence.
+ *
+ * This type is returned by the .next() method on a CombinedSequence instance.
+ */
+public class CombinedSequenceSnapshot {
+    private final long sequenceNumber;
+    private final int overflow;
+
+    CombinedSequenceSnapshot(long sequenceNumber, int overflow) {
+        this.sequenceNumber = sequenceNumber;
+        this.overflow = overflow;
+    }
+
+    public long getSequenceNumber() {
+        return sequenceNumber;
+    }
+
+    public int getOverflow() {
+        return overflow;
+    }
+
+    public long getCombinedSequence() {
+        long combined = (long)this.overflow << 32 | this.sequenceNumber;
+        assert combined >= 0 && combined < (1L << 48); // Sanity check
+        return combined;
+    }
+}

--- a/src/main/java/org/saltyrtc/client/signaling/InitiatorSignaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/InitiatorSignaling.java
@@ -34,6 +34,7 @@ import org.saltyrtc.client.messages.s2c.DropResponder;
 import org.saltyrtc.client.messages.s2c.InitiatorServerAuth;
 import org.saltyrtc.client.messages.s2c.NewResponder;
 import org.saltyrtc.client.nonce.CombinedSequence;
+import org.saltyrtc.client.nonce.CombinedSequenceSnapshot;
 import org.saltyrtc.client.nonce.SignalingChannelNonce;
 import org.saltyrtc.client.signaling.state.ResponderHandshakeState;
 import org.saltyrtc.client.signaling.state.ServerHandshakeState;
@@ -94,7 +95,7 @@ public class InitiatorSignaling extends Signaling {
     }
 
     @Override
-    protected CombinedSequence getNextCsn(short receiver) throws ProtocolException {
+    protected CombinedSequenceSnapshot getNextCsn(short receiver) throws ProtocolException {
         try {
             if (receiver == SALTYRTC_ADDR_SERVER) {
                 return this.serverCsn.getOurs().next();

--- a/src/main/java/org/saltyrtc/client/signaling/ResponderSignaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/ResponderSignaling.java
@@ -35,6 +35,7 @@ import org.saltyrtc.client.messages.s2c.ClientHello;
 import org.saltyrtc.client.messages.s2c.NewInitiator;
 import org.saltyrtc.client.messages.s2c.ResponderServerAuth;
 import org.saltyrtc.client.nonce.CombinedSequence;
+import org.saltyrtc.client.nonce.CombinedSequenceSnapshot;
 import org.saltyrtc.client.nonce.SignalingChannelNonce;
 import org.saltyrtc.client.signaling.state.InitiatorHandshakeState;
 import org.saltyrtc.client.signaling.state.ServerHandshakeState;
@@ -99,7 +100,7 @@ public class ResponderSignaling extends Signaling {
     }
 
     @Override
-    protected CombinedSequence getNextCsn(short receiver) throws ProtocolException {
+    protected CombinedSequenceSnapshot getNextCsn(short receiver) throws ProtocolException {
         try {
             if (receiver == Signaling.SALTYRTC_ADDR_SERVER) {
                 return this.serverCsn.getOurs().next();

--- a/src/main/java/org/saltyrtc/client/signaling/Signaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/Signaling.java
@@ -44,6 +44,7 @@ import org.saltyrtc.client.messages.s2c.SendError;
 import org.saltyrtc.client.messages.s2c.ServerHello;
 import org.saltyrtc.client.nonce.CombinedSequence;
 import org.saltyrtc.client.nonce.CombinedSequencePair;
+import org.saltyrtc.client.nonce.CombinedSequenceSnapshot;
 import org.saltyrtc.client.nonce.SignalingChannelNonce;
 import org.saltyrtc.client.signaling.state.HandoverState;
 import org.saltyrtc.client.signaling.state.ServerHandshakeState;
@@ -446,7 +447,7 @@ public abstract class Signaling implements SignalingInterface {
      */
     byte[] buildPacket(Message msg, short receiver, boolean encrypt) throws ProtocolException {
         // Choose proper combined sequence number
-        final CombinedSequence csn = this.getNextCsn(receiver);
+        final CombinedSequenceSnapshot csn = this.getNextCsn(receiver);
 
         // Create nonce
         final SignalingChannelNonce nonce = new SignalingChannelNonce(
@@ -760,7 +761,7 @@ public abstract class Signaling implements SignalingInterface {
     /**
      * Choose proper combined sequence number
      */
-    abstract CombinedSequence getNextCsn(short receiver) throws ProtocolException;
+    abstract CombinedSequenceSnapshot getNextCsn(short receiver) throws ProtocolException;
 
     /**
      * Return `true` if receiver byte is a valid responder id (in the range 0x02-0xff).

--- a/src/test/java/org/saltyrtc/client/tests/nonce/CombinedSequenceTest.java
+++ b/src/test/java/org/saltyrtc/client/tests/nonce/CombinedSequenceTest.java
@@ -114,7 +114,9 @@ public class CombinedSequenceTest {
             threads.add(new Incrementor());
             expected.add(i);
         }
-        threads.forEach(Thread::start);
+        for (Thread incrementor : threads) {
+            incrementor.start();
+        }
         for (Thread incrementor : threads) {
             incrementor.join();
         }

--- a/src/test/java/org/saltyrtc/client/tests/nonce/CombinedSequenceTest.java
+++ b/src/test/java/org/saltyrtc/client/tests/nonce/CombinedSequenceTest.java
@@ -11,13 +11,18 @@ package org.saltyrtc.client.tests.nonce;
 import org.junit.Test;
 import org.saltyrtc.client.exceptions.OverflowException;
 import org.saltyrtc.client.nonce.CombinedSequence;
+import org.saltyrtc.client.nonce.CombinedSequenceSnapshot;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.BrokenBarrierException;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class CombinedSequenceTest {
@@ -50,8 +55,7 @@ public class CombinedSequenceTest {
         } while (!valid);
         final long oldSequence = cs.getSequenceNumber();
         final int oldOverflow = cs.getOverflow();
-        CombinedSequence incremented = cs.next();
-        assertSame(cs, incremented);
+        CombinedSequenceSnapshot incremented = cs.next();
         assertEquals(oldSequence + 1, incremented.getSequenceNumber());
         assertEquals(oldOverflow, incremented.getOverflow());
     }
@@ -82,5 +86,40 @@ public class CombinedSequenceTest {
 
         // This will throw
         cs.next();
+    }
+
+    /**
+     * Make sure the next() method is thread safe.
+     */
+    @Test
+    public void testThreadSafety() throws InterruptedException, BrokenBarrierException {
+        final int THREAD_COUNT = 100;
+
+        final CombinedSequence cs = new CombinedSequence(0, 0);
+        final List<Long> list = Collections.synchronizedList(new ArrayList<Long>());
+        final List<Thread> threads = Collections.synchronizedList(new ArrayList<Thread>());
+        final List<Long> expected = new ArrayList<>();
+
+        class Incrementor extends Thread {
+            public void run() {
+                try {
+                    list.add(cs.next().getCombinedSequence());
+                } catch (OverflowException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        for (Long i = 1L; i <= THREAD_COUNT; i++) {
+            threads.add(new Incrementor());
+            expected.add(i);
+        }
+        threads.forEach(Thread::start);
+        for (Thread incrementor : threads) {
+            incrementor.join();
+        }
+
+        Collections.sort(list);
+        assertArrayEquals("List was " + list, expected.toArray(), list.toArray());
     }
 }


### PR DESCRIPTION
There were two problems in the CombinedSequence class:

* The `next()` method was not synchronized, leading to potential
  concurrent modification of the class attributes.
* Even if the `next()` method is synchronized, the return value is a
  reference to the instance itself. This means that a call to
  `.next().getCombinedSequence()` could return an unexpected result if
  the instance has been modified by another thread in the meantime.

The solution is to return an immutable `CombinedSequenceSnapshot`
instead.

A regression test with 100 concurrent threads is included.