### PR TITLE
New cookie per peer

### DIFF
--- a/src/main/java/org/saltyrtc/client/cookie/CookiePair.java
+++ b/src/main/java/org/saltyrtc/client/cookie/CookiePair.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2016 Threema GmbH / SaltyRTC Contributors
+ *
+ * Licensed under the Apache License, Version 2.0, <see LICENSE-APACHE file>
+ * or the MIT license <see LICENSE-MIT file>, at your option. This file may not be
+ * copied, modified, or distributed except according to those terms.
+ */
+package org.saltyrtc.client.cookie;
+
+import org.saltyrtc.client.annotations.NonNull;
+import org.saltyrtc.client.annotations.Nullable;
+import org.saltyrtc.client.exceptions.ProtocolException;
+
+/**
+ * A SaltyRTC cookie pair.
+ *
+ * The implementation ensures that local and peer cookie are never the same.
+ */
+public class CookiePair {
+    private final Cookie ours;
+    private Cookie theirs = null;
+
+    public CookiePair() {
+        this.ours = new Cookie();
+    }
+
+	/**
+     * Create a new cookie pair with a predefined peer cookie.
+     */
+    public CookiePair(Cookie theirs) {
+        Cookie cookie;
+        do {
+            cookie = new Cookie();
+        } while (cookie.equals(theirs));
+        this.ours = cookie;
+        this.theirs = theirs;
+    }
+
+	/**
+     * Create a new cookie pair.
+     *
+     * May throw ProtocolException if both cookies are the same.
+     */
+    public CookiePair(Cookie ours, Cookie theirs) throws ProtocolException {
+        if (theirs.equals(ours)) {
+            throw new ProtocolException("Their cookie matches our cookie");
+        }
+        this.ours = ours;
+        this.theirs = theirs;
+    }
+
+    @NonNull
+    public Cookie getOurs() {
+        return this.ours;
+    }
+
+    public boolean hasTheirs() {
+        return this.theirs != null;
+    }
+
+    @Nullable
+    public Cookie getTheirs() {
+        return this.theirs;
+    }
+
+	/**
+     * Set peer cookie.
+     *
+     * May throw ProtocolException if peer cookie matches our cookie.
+     */
+    public void setTheirs(Cookie theirs) throws ProtocolException {
+        if (theirs.equals(this.ours)) {
+            throw new ProtocolException("Their cookie matches our cookie");
+        }
+        this.theirs = theirs;
+    }
+}

--- a/src/main/java/org/saltyrtc/client/signaling/Initiator.java
+++ b/src/main/java/org/saltyrtc/client/signaling/Initiator.java
@@ -14,12 +14,14 @@ import org.saltyrtc.client.signaling.state.InitiatorHandshakeState;
  * Information about the initiator. Used by responder during handshake.
  */
 public class Initiator extends Peer {
+    private static short ID = 0x01;
+
     private boolean connected;
 
     public InitiatorHandshakeState handshakeState;
 
     public Initiator(byte[] permanentKey) {
-        super(permanentKey);
+        super(Initiator.ID, permanentKey);
         this.connected = false;
         this.handshakeState = InitiatorHandshakeState.NEW;
     }

--- a/src/main/java/org/saltyrtc/client/signaling/Initiator.java
+++ b/src/main/java/org/saltyrtc/client/signaling/Initiator.java
@@ -21,13 +21,10 @@ public class Initiator extends Peer {
     public InitiatorHandshakeState handshakeState;
 
     public Initiator(byte[] permanentKey) {
-        super(Initiator.ID, permanentKey);
+        super(Initiator.ID);
+        this.permanentKey = permanentKey;
         this.connected = false;
         this.handshakeState = InitiatorHandshakeState.NEW;
-    }
-
-    public short getId() {
-        return 0x01;
     }
 
     public boolean isConnected() {

--- a/src/main/java/org/saltyrtc/client/signaling/InitiatorSignaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/InitiatorSignaling.java
@@ -85,7 +85,7 @@ public class InitiatorSignaling extends Signaling {
     protected CombinedSequenceSnapshot getNextCsn(short receiver) throws ProtocolException {
         try {
             if (receiver == SALTYRTC_ADDR_SERVER) {
-                return this.serverCsn.getOurs().next();
+                return this.server.getCsnPair().getOurs().next();
             } else if (receiver == SALTYRTC_ADDR_INITIATOR) {
                 throw new ProtocolException("Initiator cannot send messages to initiator");
             } else if (this.isResponderId(receiver)) {
@@ -235,7 +235,7 @@ public class InitiatorSignaling extends Signaling {
             // Nonce claims to come from server.
             // Try to decrypt data accordingly.
             try {
-                assert this.server != null;
+                assert this.server.hasSessionKey();
                 payload = this.permanentKey.decrypt(box, this.server.getSessionKey());
             } catch (CryptoFailedException | InvalidKeyException e) {
                 e.printStackTrace();

--- a/src/main/java/org/saltyrtc/client/signaling/InitiatorSignaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/InitiatorSignaling.java
@@ -45,7 +45,6 @@ import org.slf4j.Logger;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import javax.net.ssl.SSLContext;
 
@@ -184,11 +183,12 @@ public class InitiatorSignaling extends Signaling {
         this.address = SALTYRTC_ADDR_INITIATOR;
 
         // Validate cookie
-        final Cookie cookie = new Cookie(msg.getYourCookie());
-        if (!cookie.equals(this.cookie)) {
+        final Cookie repeatedCookie = new Cookie(msg.getYourCookie());
+        final Cookie ourCookie = this.server.getCookiePair().getOurs();
+        if (!repeatedCookie.equals(ourCookie)) {
             this.getLogger().error("Bad repeated cookie in server-auth message");
-            this.getLogger().debug("Their response: " + Arrays.toString(msg.getYourCookie()) +
-                              ", our cookie: " + Arrays.toString(this.cookie.getBytes()));
+            this.getLogger().debug("Their response: " + Arrays.toString(repeatedCookie.getBytes()) +
+                              ", our cookie: " + Arrays.toString(ourCookie.getBytes()));
             throw new ProtocolException("Bad repeated cookie in server-auth message");
         }
 
@@ -270,7 +270,7 @@ public class InitiatorSignaling extends Signaling {
                         payload = this.authToken.decrypt(box);
                     } catch (CryptoFailedException e) {
                         this.getLogger().warn("Could not decrypt token message");
-                        this.dropResponder(responder.getId()); // TODO: Reason
+                        this.dropResponder(responder); // TODO: Reason
                         return;
                     }
                     msg = MessageReader.read(payload);
@@ -291,7 +291,7 @@ public class InitiatorSignaling extends Signaling {
                         payload = this.permanentKey.decrypt(box, peerPublicKey);
                     } catch (CryptoFailedException e) {
                         this.getLogger().warn("Could not decrypt key message");
-                        this.dropResponder(responder.getId());
+                        this.dropResponder(responder);
                         return;
                     } catch (InvalidKeyException e) {
                         e.printStackTrace();
@@ -420,7 +420,7 @@ public class InitiatorSignaling extends Signaling {
      */
     private void sendKey(Responder responder) throws SignalingException, ConnectionException {
         final Key msg = new Key(responder.getKeyStore().getPublicKey());
-        final byte[] packet = this.buildPacket(msg, responder.getId());
+        final byte[] packet = this.buildPacket(msg, responder);
         this.getLogger().debug("Sending key");
         this.send(packet, msg);
         responder.handshakeState = ResponderHandshakeState.KEY_SENT;
@@ -431,7 +431,7 @@ public class InitiatorSignaling extends Signaling {
      */
     private void handleAuth(ResponderAuth msg, Responder responder, SignalingChannelNonce nonce) throws SignalingException {
         // Validate cookie
-        this.validateRepeatedCookie(msg.getYourCookie());
+        this.validateRepeatedCookie(responder, msg.getYourCookie());
 
         // Validation of task list and data already happens in the `ResponderAuth` constructor
 
@@ -450,10 +450,7 @@ public class InitiatorSignaling extends Signaling {
         this.getLogger().debug("Responder 0x" + NaCl.asHex(new int[] { responder.getId() }) + " authenticated");
 
         // Store cookie
-        if (nonce.getCookie().equals(this.cookie)) {
-            throw new ProtocolException("Local and remote cookies are equal");
-        }
-        responder.setCookie(nonce.getCookie());
+        responder.getCookiePair().setTheirs(nonce.getCookie());
 
         // Update state
         responder.handshakeState = ResponderHandshakeState.AUTH_RECEIVED;
@@ -463,11 +460,6 @@ public class InitiatorSignaling extends Signaling {
      * Repeat the responder's cookie and choose a task.
      */
     private void sendAuth(Responder responder, SignalingChannelNonce nonce) throws SignalingException, ConnectionException {
-        // Ensure that cookies are different
-        if (nonce.getCookie().equals(this.cookie)) {
-            throw new ProtocolException("Their cookie and our cookie are the same");
-        }
-
         // Send auth
         final InitiatorAuth msg;
         try {
@@ -477,7 +469,7 @@ public class InitiatorSignaling extends Signaling {
         } catch (ValidationError e) {
             throw new ProtocolException("Invalid task data", e);
         }
-        final byte[] packet = this.buildPacket(msg, responder.getId());
+        final byte[] packet = this.buildPacket(msg, responder);
         this.getLogger().debug("Sending auth");
         this.send(packet, msg);
 
@@ -488,12 +480,12 @@ public class InitiatorSignaling extends Signaling {
     /**
      * Drop specific responder.
      */
-    private void dropResponder(short responderId) throws SignalingException, ConnectionException {
-        final DropResponder msg = new DropResponder(responderId);
-        final byte[] packet = this.buildPacket(msg, responderId);
-        this.getLogger().debug("Sending drop-responder " + responderId);
+    private void dropResponder(Responder responder) throws SignalingException, ConnectionException {
+        final DropResponder msg = new DropResponder(responder.getId());
+        final byte[] packet = this.buildPacket(msg, responder);
+        this.getLogger().debug("Sending drop-responder " + responder.getId());
         this.send(packet, msg);
-        this.responders.remove(responderId);
+        this.responders.remove(responder.getId());
     }
 
     /**
@@ -501,28 +493,15 @@ public class InitiatorSignaling extends Signaling {
      */
     private void dropResponders() throws SignalingException, ConnectionException {
         this.getLogger().debug("Dropping " + this.responders.size() + " other responders");
-        final Set<Short> ids = this.responders.keySet();
-        for (short id : ids) {
-            this.dropResponder(id);
+        for (Responder responder : this.responders.values()) {
+            this.dropResponder(responder);
         }
     }
 
     @Override
     @Nullable
-    protected Short getPeerAddress() {
-        if (this.responder != null) {
-            return this.responder.getId();
-        }
-        return null;
-    }
-
-    @Override
-    @Nullable
-    public Cookie getPeerCookie() {
-        if (this.responder != null) {
-            return this.responder.getCookie();
-        }
-        return null;
+    protected Peer getPeer() {
+        return this.responder;
     }
 
     @Override

--- a/src/main/java/org/saltyrtc/client/signaling/InitiatorSignaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/InitiatorSignaling.java
@@ -212,7 +212,7 @@ public class InitiatorSignaling extends Signaling {
         this.getLogger().debug(this.responders.size() + " responder(s) connected.");
 
         // Server handshake is done!
-        this.serverHandshakeState = ServerHandshakeState.DONE;
+        this.server.handshakeState = ServerHandshakeState.DONE;
     }
 
     @Override

--- a/src/main/java/org/saltyrtc/client/signaling/InitiatorSignaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/InitiatorSignaling.java
@@ -235,7 +235,8 @@ public class InitiatorSignaling extends Signaling {
             // Nonce claims to come from server.
             // Try to decrypt data accordingly.
             try {
-                payload = this.permanentKey.decrypt(box, this.serverSessionKey);
+                assert this.server != null;
+                payload = this.permanentKey.decrypt(box, this.server.getSessionKey());
             } catch (CryptoFailedException | InvalidKeyException e) {
                 e.printStackTrace();
                 throw new ProtocolException("Could not decrypt server message");

--- a/src/main/java/org/saltyrtc/client/signaling/Peer.java
+++ b/src/main/java/org/saltyrtc/client/signaling/Peer.java
@@ -8,22 +8,50 @@
 
 package org.saltyrtc.client.signaling;
 
-import org.saltyrtc.client.cookie.Cookie;
+import org.saltyrtc.client.annotations.NonNull;
+import org.saltyrtc.client.cookie.CookiePair;
 import org.saltyrtc.client.nonce.CombinedSequencePair;
 
+/**
+ * Either the server, the initiator or a responder.
+ */
 public abstract class Peer {
-    protected byte[] permanentKey;
-    protected byte[] sessionKey;
-    protected final CombinedSequencePair csnPair;
-    protected Cookie cookie;
+    short id;
+    byte[] permanentKey;
+    byte[] sessionKey;
+    @NonNull
+    private final CombinedSequencePair csnPair;
+    @NonNull
+    private CookiePair cookiePair;
 
-    public Peer() {
+	/**
+     * Initialize a peer with just an ID.
+     */
+    public Peer(short id) {
+        this.id = id;
+        this.csnPair = new CombinedSequencePair();
+        this.cookiePair = new CookiePair();
+    }
+
+	/**
+     * Initialize a peer with an permanent key.
+     */
+    public Peer(short id, byte[] permanentKey) {
+        this(id);
+        this.permanentKey = permanentKey;
+    }
+
+	/**
+     * Initialize a peer with a cookie pair.
+     */
+    public Peer(short id, CookiePair cookiePair) {
+        this.id = id;
+        this.cookiePair = cookiePair;
         this.csnPair = new CombinedSequencePair();
     }
 
-    public Peer(byte[] permanentKey) {
-        this();
-        this.permanentKey = permanentKey;
+    public short getId() {
+        return id;
     }
 
     public byte[] getPermanentKey() {
@@ -42,21 +70,16 @@ public abstract class Peer {
         this.sessionKey = sessionKey;
     }
 
+    @NonNull
     public CombinedSequencePair getCsnPair() {
         return this.csnPair;
     }
 
     /**
-     * Return the peer cookie.
+     * Return the cookie pair.
      */
-    public Cookie getCookie() {
-        return cookie;
-    }
-
-    /**
-     * Set the peer cookie.
-     */
-    public void setCookie(Cookie cookie) {
-        this.cookie = cookie;
+    @NonNull
+    public CookiePair getCookiePair() {
+        return this.cookiePair;
     }
 }

--- a/src/main/java/org/saltyrtc/client/signaling/Peer.java
+++ b/src/main/java/org/saltyrtc/client/signaling/Peer.java
@@ -9,6 +9,7 @@
 package org.saltyrtc.client.signaling;
 
 import org.saltyrtc.client.annotations.NonNull;
+import org.saltyrtc.client.annotations.Nullable;
 import org.saltyrtc.client.cookie.CookiePair;
 import org.saltyrtc.client.nonce.CombinedSequencePair;
 
@@ -16,13 +17,20 @@ import org.saltyrtc.client.nonce.CombinedSequencePair;
  * Either the server, the initiator or a responder.
  */
 public abstract class Peer {
-    short id;
-    byte[] permanentKey;
-    byte[] sessionKey;
-    @NonNull
-    private final CombinedSequencePair csnPair;
-    @NonNull
-    private CookiePair cookiePair;
+    // Receiver id
+    private short id;
+
+    // Permanent key of the peer
+    @Nullable byte[] permanentKey;
+
+    // Session key of the peer
+    @Nullable byte[] sessionKey;
+
+    // CSN pair
+    @NonNull private final CombinedSequencePair csnPair;
+
+    // Cookie pair
+    @NonNull private CookiePair cookiePair;
 
 	/**
      * Initialize a peer with just an ID.
@@ -34,17 +42,9 @@ public abstract class Peer {
     }
 
 	/**
-     * Initialize a peer with an permanent key.
-     */
-    public Peer(short id, byte[] permanentKey) {
-        this(id);
-        this.permanentKey = permanentKey;
-    }
-
-	/**
      * Initialize a peer with a cookie pair.
      */
-    public Peer(short id, CookiePair cookiePair) {
+    public Peer(short id, @NonNull CookiePair cookiePair) {
         this.id = id;
         this.cookiePair = cookiePair;
         this.csnPair = new CombinedSequencePair();
@@ -54,20 +54,30 @@ public abstract class Peer {
         return id;
     }
 
+    @Nullable
     public byte[] getPermanentKey() {
         return this.permanentKey;
     }
 
-    public void setPermanentKey(byte[] permanentKey) {
+    public void setPermanentKey(@Nullable byte[] permanentKey) {
         this.permanentKey = permanentKey;
     }
 
+    public boolean hasPermanentKey() {
+        return this.permanentKey != null;
+    }
+
+    @Nullable
     public byte[] getSessionKey() {
         return this.sessionKey;
     }
 
-    public void setSessionKey(byte[] sessionKey) {
+    public void setSessionKey(@Nullable byte[] sessionKey) {
         this.sessionKey = sessionKey;
+    }
+
+    public boolean hasSessionKey() {
+        return this.sessionKey != null;
     }
 
     @NonNull

--- a/src/main/java/org/saltyrtc/client/signaling/Responder.java
+++ b/src/main/java/org/saltyrtc/client/signaling/Responder.java
@@ -15,19 +15,13 @@ import org.saltyrtc.client.signaling.state.ResponderHandshakeState;
  * Information about a responder. Used by initiator during handshake.
  */
 public class Responder extends Peer {
-    private final short id;
     private final KeyStore keyStore;
     public ResponderHandshakeState handshakeState;
 
     public Responder(short id) {
-        super();
-        this.id = id;
+        super(id);
         this.keyStore = new KeyStore();
         this.handshakeState = ResponderHandshakeState.NEW;
-    }
-
-    public short getId() {
-        return id;
     }
 
     public KeyStore getKeyStore() {

--- a/src/main/java/org/saltyrtc/client/signaling/ResponderSignaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/ResponderSignaling.java
@@ -352,7 +352,8 @@ public class ResponderSignaling extends Signaling {
             // Nonce claims to come from server.
             // Try to decrypt data accordingly.
             try {
-                payload = this.permanentKey.decrypt(box, this.serverSessionKey);
+                assert this.server != null;
+                payload = this.permanentKey.decrypt(box, this.server.getSessionKey());
             } catch (CryptoFailedException | InvalidKeyException e) {
                 e.printStackTrace();
                 throw new ProtocolException("Could not decrypt server message");

--- a/src/main/java/org/saltyrtc/client/signaling/ResponderSignaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/ResponderSignaling.java
@@ -146,7 +146,7 @@ public class ResponderSignaling extends Signaling {
         final byte[] packet = this.buildPacket(msg, this.server, false);
         this.getLogger().debug("Sending client-hello");
         this.send(packet, msg);
-        this.serverHandshakeState = ServerHandshakeState.HELLO_SENT;
+        this.server.handshakeState = ServerHandshakeState.HELLO_SENT;
     }
 
     @Override
@@ -193,7 +193,7 @@ public class ResponderSignaling extends Signaling {
         this.getLogger().debug("Initiator is " + (msg.isInitiatorConnected() ? "" : "not ") + "connected.");
 
         // Server handshake is done!
-        this.serverHandshakeState = ServerHandshakeState.DONE;
+        this.server.handshakeState = ServerHandshakeState.DONE;
     }
 
     @Override

--- a/src/main/java/org/saltyrtc/client/signaling/ResponderSignaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/ResponderSignaling.java
@@ -99,7 +99,7 @@ public class ResponderSignaling extends Signaling {
     protected CombinedSequenceSnapshot getNextCsn(short receiver) throws ProtocolException {
         try {
             if (receiver == Signaling.SALTYRTC_ADDR_SERVER) {
-                return this.serverCsn.getOurs().next();
+                return this.server.getCsnPair().getOurs().next();
             } else if (receiver == Signaling.SALTYRTC_ADDR_INITIATOR) {
                 return this.initiator.getCsnPair().getOurs().next();
             } else if (this.isResponderId(receiver)) {
@@ -352,7 +352,7 @@ public class ResponderSignaling extends Signaling {
             // Nonce claims to come from server.
             // Try to decrypt data accordingly.
             try {
-                assert this.server != null;
+                assert this.server.hasSessionKey();
                 payload = this.permanentKey.decrypt(box, this.server.getSessionKey());
             } catch (CryptoFailedException | InvalidKeyException e) {
                 e.printStackTrace();

--- a/src/main/java/org/saltyrtc/client/signaling/ResponderSignaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/ResponderSignaling.java
@@ -16,7 +16,6 @@ import org.saltyrtc.client.exceptions.ConnectionException;
 import org.saltyrtc.client.exceptions.CryptoFailedException;
 import org.saltyrtc.client.exceptions.InternalException;
 import org.saltyrtc.client.exceptions.InvalidKeyException;
-import org.saltyrtc.client.exceptions.OverflowException;
 import org.saltyrtc.client.exceptions.ProtocolException;
 import org.saltyrtc.client.exceptions.SerializationError;
 import org.saltyrtc.client.exceptions.SignalingException;
@@ -34,7 +33,6 @@ import org.saltyrtc.client.messages.c2c.Token;
 import org.saltyrtc.client.messages.s2c.ClientHello;
 import org.saltyrtc.client.messages.s2c.NewInitiator;
 import org.saltyrtc.client.messages.s2c.ResponderServerAuth;
-import org.saltyrtc.client.nonce.CombinedSequenceSnapshot;
 import org.saltyrtc.client.nonce.SignalingChannelNonce;
 import org.saltyrtc.client.signaling.state.InitiatorHandshakeState;
 import org.saltyrtc.client.signaling.state.ServerHandshakeState;
@@ -93,23 +91,6 @@ public class ResponderSignaling extends Signaling {
     @Override
     protected String getWebsocketPath() {
         return NaCl.asHex(this.initiator.getPermanentKey());
-    }
-
-    @Override
-    protected CombinedSequenceSnapshot getNextCsn(short receiver) throws ProtocolException {
-        try {
-            if (receiver == Signaling.SALTYRTC_ADDR_SERVER) {
-                return this.server.getCsnPair().getOurs().next();
-            } else if (receiver == Signaling.SALTYRTC_ADDR_INITIATOR) {
-                return this.initiator.getCsnPair().getOurs().next();
-            } else if (this.isResponderId(receiver)) {
-                throw new ProtocolException("Responder may not send messages to other responders: " + receiver);
-            } else {
-                throw new ProtocolException("Bad receiver byte: " + receiver);
-            }
-        } catch (OverflowException e) {
-            throw new ProtocolException("OverflowException: " + e.getMessage());
-        }
     }
 
     @Override

--- a/src/main/java/org/saltyrtc/client/signaling/Server.java
+++ b/src/main/java/org/saltyrtc/client/signaling/Server.java
@@ -1,0 +1,14 @@
+package org.saltyrtc.client.signaling;
+
+import org.saltyrtc.client.cookie.CookiePair;
+
+/**
+ * Information about the server.
+ */
+public class Server extends Peer {
+    private static short ID = 0x00;
+
+    public Server(CookiePair cookiePair) {
+        super(Server.ID, cookiePair);
+    }
+}

--- a/src/main/java/org/saltyrtc/client/signaling/Server.java
+++ b/src/main/java/org/saltyrtc/client/signaling/Server.java
@@ -1,10 +1,14 @@
 package org.saltyrtc.client.signaling;
 
+import org.saltyrtc.client.signaling.state.ServerHandshakeState;
+
 /**
  * Information about the server.
  */
 public class Server extends Peer {
     private static short ID = 0x00;
+
+    public ServerHandshakeState handshakeState = ServerHandshakeState.NEW;
 
     public Server() {
         super(Server.ID);

--- a/src/main/java/org/saltyrtc/client/signaling/Server.java
+++ b/src/main/java/org/saltyrtc/client/signaling/Server.java
@@ -1,5 +1,6 @@
 package org.saltyrtc.client.signaling;
 
+import org.saltyrtc.client.annotations.NonNull;
 import org.saltyrtc.client.cookie.CookiePair;
 
 /**
@@ -8,7 +9,8 @@ import org.saltyrtc.client.cookie.CookiePair;
 public class Server extends Peer {
     private static short ID = 0x00;
 
-    public Server(CookiePair cookiePair) {
+    public Server(@NonNull CookiePair cookiePair, @NonNull byte[] sessionKey) {
         super(Server.ID, cookiePair);
+        this.setSessionKey(sessionKey);
     }
 }

--- a/src/main/java/org/saltyrtc/client/signaling/Server.java
+++ b/src/main/java/org/saltyrtc/client/signaling/Server.java
@@ -1,16 +1,12 @@
 package org.saltyrtc.client.signaling;
 
-import org.saltyrtc.client.annotations.NonNull;
-import org.saltyrtc.client.cookie.CookiePair;
-
 /**
  * Information about the server.
  */
 public class Server extends Peer {
     private static short ID = 0x00;
 
-    public Server(@NonNull CookiePair cookiePair, @NonNull byte[] sessionKey) {
-        super(Server.ID, cookiePair);
-        this.setSessionKey(sessionKey);
+    public Server() {
+        super(Server.ID);
     }
 }

--- a/src/main/java/org/saltyrtc/client/signaling/Signaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/Signaling.java
@@ -78,7 +78,6 @@ public abstract class Signaling implements SignalingInterface {
     // WebSocket
     private final String host;
     private final int port;
-    private final String protocol = "wss";
     private final SSLContext sslContext;
     private WebSocket ws;
 
@@ -90,44 +89,38 @@ public abstract class Signaling implements SignalingInterface {
     private final SaltyRTC salty;
 
     // Server information
-    @Nullable
-    Server server;
+    @Nullable Server server;
 
     // Our keys
-    @NonNull
-    final KeyStore permanentKey;
+    @NonNull final KeyStore permanentKey;
     KeyStore sessionKey;
 
     // Peer trusted key or auth token
-    @Nullable
-    AuthToken authToken;
-    @Nullable
-    byte[] peerTrustedKey;
+    @Nullable AuthToken authToken;
+    @Nullable byte[] peerTrustedKey;
 
     // Server trusted key
-    @Nullable
-    byte[] expectedServerKey;
+    @Nullable byte[] expectedServerKey;
 
     // Signaling
-    @NonNull
-    private SignalingRole role;
+    @NonNull private SignalingRole role;
     short address = SALTYRTC_ADDR_UNKNOWN;
     CombinedSequencePair serverCsn = new CombinedSequencePair();
     ServerHandshakeState serverHandshakeState = ServerHandshakeState.NEW;
 
     // Tasks
-    final Task[] tasks;
-    Task task = null;
+    @NonNull final Task[] tasks;
+    Task task;
 
     // Message history
     private final MessageHistory history = new MessageHistory(10);
 
     public Signaling(SaltyRTC salty, String host, int port,
-                     KeyStore permanentKey, SSLContext sslContext,
+                     @NonNull KeyStore permanentKey, SSLContext sslContext,
                      @Nullable byte[] peerTrustedKey,
                      @Nullable byte[] expectedServerKey,
-                     SignalingRole role,
-                     Task[] tasks) {
+                     @NonNull SignalingRole role,
+                     @NonNull Task[] tasks) {
         this.salty = salty;
         this.host = host;
         this.port = port;
@@ -278,7 +271,7 @@ public abstract class Signaling implements SignalingInterface {
      */
     private void initWebsocket() throws IOException {
         // Build connection URL
-        final String baseUrl = this.protocol + "://" + this.host + ":" + this.port + "/";
+        final String baseUrl = "wss://" + this.host + ":" + this.port + "/";
         final URI uri = URI.create(baseUrl + this.getWebsocketPath());
         this.getLogger().debug("Initialize WebSocket connection to " + uri);
 


### PR DESCRIPTION
Every peer gets a new cookie and CSN.

- Introduce `Server` class that extends `Peer`
- Put all server state into that instance
- Get rid of `getNextCsn` method

Refs #19