### PR TITLE
Retry WebSocket connection

### DIFF
--- a/src/main/java/org/saltyrtc/client/SaltyRTC.java
+++ b/src/main/java/org/saltyrtc/client/SaltyRTC.java
@@ -131,7 +131,7 @@ public class SaltyRTC {
      * Connect asynchronously to the SaltyRTC server.
      *
      * To get notified when the connection is up and running,
-     * subscribe to the `ConnectedEvent`.
+     * subscribe to the `SignalingStateChangedEvent`.
      *
      * @throws ConnectionException if setting up the WebSocket connection fails.
      */


### PR DESCRIPTION
Retry once if connecting fails.

This could be extended in the future to include exponential backoff.

Fixes #63.