### PR TITLE
Configurable retry attempts and linear backoff

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
 apply plugin: 'witness'
 apply plugin: 'maven'
 
-def app_version = '0.10.1'
+def app_version = '0.12.0'
 
 targetCompatibility = '1.7'
 sourceCompatibility = '1.7'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
 apply plugin: 'witness'
 apply plugin: 'maven'
 
-def app_version = '0.12.0'
+def app_version = '0.11.1'
 
 targetCompatibility = '1.7'
 sourceCompatibility = '1.7'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
 apply plugin: 'witness'
 apply plugin: 'maven'
 
-def app_version = '0.11.1'
+def app_version = '0.10.1'
 
 targetCompatibility = '1.7'
 sourceCompatibility = '1.7'

--- a/src/main/java/org/saltyrtc/client/SaltyRTC.java
+++ b/src/main/java/org/saltyrtc/client/SaltyRTC.java
@@ -55,12 +55,14 @@ public class SaltyRTC {
     SaltyRTC(KeyStore permanentKey, String host, int port,
              @Nullable SSLContext sslContext,
              @Nullable Integer wsConnectTimeout,
+             @Nullable Integer wsConnectAttemptsMax,
+             @Nullable Boolean wsConnectLinearBackoff,
              @Nullable byte[] serverKey,
              Task[] tasks, int pingInterval)
              throws InvalidKeyException {
         this.signaling = new InitiatorSignaling(
-            this, host, port, sslContext, wsConnectTimeout, permanentKey,
-            null, serverKey, tasks, pingInterval);
+            this, host, port, sslContext, wsConnectTimeout, wsConnectAttemptsMax, wsConnectLinearBackoff,
+            permanentKey, null, serverKey, tasks, pingInterval);
     }
 
     // Internal constructor used by SaltyRTCBuilder.
@@ -68,12 +70,14 @@ public class SaltyRTC {
     SaltyRTC(KeyStore permanentKey, String host, int port,
              @Nullable SSLContext sslContext,
              @Nullable Integer wsConnectTimeout,
+             @Nullable Integer wsConnectAttemptsMax,
+             @Nullable Boolean wsConnectLinearBackoff,
              byte[] initiatorPublicKey, byte[] authToken,
              @Nullable byte[] serverKey, Task[] tasks, int pingInterval)
              throws InvalidKeyException {
         this.signaling = new ResponderSignaling(
-            this, host, port, sslContext, wsConnectTimeout, permanentKey,
-            initiatorPublicKey, authToken, null, serverKey, tasks, pingInterval);
+            this, host, port, sslContext, wsConnectTimeout, wsConnectAttemptsMax, wsConnectLinearBackoff,
+            permanentKey, initiatorPublicKey, authToken, null, serverKey, tasks, pingInterval);
     }
 
     // Internal constructor used by SaltyRTCBuilder.
@@ -81,19 +85,21 @@ public class SaltyRTC {
     SaltyRTC(KeyStore permanentKey, String host, int port,
              @Nullable SSLContext sslContext,
              @Nullable Integer wsConnectTimeout,
+             @Nullable Integer wsConnectAttemptsMax,
+             @Nullable Boolean wsConnectLinearBackoff,
              byte[] peerTrustedKey, @Nullable byte[] serverKey, Task[] tasks, int pingInterval,
              SignalingRole role)
              throws InvalidKeyException {
         switch (role) {
             case Initiator:
                 this.signaling = new InitiatorSignaling(
-                    this, host, port, sslContext, wsConnectTimeout, permanentKey,
-                    peerTrustedKey, serverKey, tasks, pingInterval);
+                    this, host, port, sslContext, wsConnectTimeout, wsConnectAttemptsMax, wsConnectLinearBackoff,
+                    permanentKey, peerTrustedKey, serverKey, tasks, pingInterval);
                 break;
             case Responder:
                 this.signaling = new ResponderSignaling(
-                    this, host, port, sslContext, wsConnectTimeout, permanentKey,
-                    null, null, peerTrustedKey, serverKey, tasks, pingInterval);
+                    this, host, port, sslContext, wsConnectTimeout, wsConnectAttemptsMax, wsConnectLinearBackoff,
+                    permanentKey, null, null, peerTrustedKey, serverKey, tasks, pingInterval);
                 break;
             default:
                 throw new IllegalArgumentException("Invalid role: " + role);

--- a/src/main/java/org/saltyrtc/client/signaling/InitiatorSignaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/InitiatorSignaling.java
@@ -68,13 +68,15 @@ public class InitiatorSignaling extends Signaling {
     public InitiatorSignaling(SaltyRTC saltyRTC, String host, int port,
                               @Nullable SSLContext sslContext,
                               @Nullable Integer wsConnectTimeout,
+                              @Nullable Integer wsConnectAttemptsMax,
+                              @Nullable Boolean wsConnectLinearBackoff,
                               @NonNull KeyStore permanentKey,
                               @Nullable byte[] responderTrustedKey,
                               @Nullable byte[] expectedServerKey,
                               @NonNull Task[] tasks,
                               int pingInterval) {
-        super(saltyRTC, host, port, sslContext, wsConnectTimeout, permanentKey, responderTrustedKey, expectedServerKey,
-              SignalingRole.Initiator, tasks, pingInterval);
+        super(saltyRTC, host, port, sslContext, wsConnectTimeout, wsConnectAttemptsMax, wsConnectLinearBackoff,
+              permanentKey, responderTrustedKey, expectedServerKey, SignalingRole.Initiator, tasks, pingInterval);
         if (responderTrustedKey == null) {
             this.authToken = new AuthToken();
         }

--- a/src/main/java/org/saltyrtc/client/signaling/ResponderSignaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/ResponderSignaling.java
@@ -66,6 +66,8 @@ public class ResponderSignaling extends Signaling {
     public ResponderSignaling(SaltyRTC saltyRTC, String host, int port,
                               @Nullable SSLContext sslContext,
                               @Nullable Integer wsConnectTimeout,
+                              @Nullable Integer wsConnectAttemptsMax,
+                              @Nullable Boolean wsConnectLinearBackoff,
                               @NonNull KeyStore permanentKey,
                               @Nullable byte[] initiatorPublicKey, @Nullable byte[] authToken,
                               @Nullable byte[] initiatorTrustedKey,
@@ -73,8 +75,8 @@ public class ResponderSignaling extends Signaling {
                               @NonNull Task[] tasks,
                               int pingInterval)
                               throws InvalidKeyException {
-        super(saltyRTC, host, port, sslContext, wsConnectTimeout, permanentKey, initiatorTrustedKey, expectedServerKey,
-              SignalingRole.Responder, tasks, pingInterval);
+        super(saltyRTC, host, port, sslContext, wsConnectTimeout, wsConnectAttemptsMax, wsConnectLinearBackoff,
+              permanentKey, initiatorTrustedKey, expectedServerKey, SignalingRole.Responder, tasks, pingInterval);
         if (initiatorTrustedKey != null) {
             if (initiatorPublicKey != null || authToken != null) {
                 throw new IllegalArgumentException(

--- a/src/main/java/org/saltyrtc/client/signaling/Signaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/Signaling.java
@@ -78,7 +78,9 @@ import javax.net.ssl.SSLContext;
 public abstract class Signaling implements SignalingInterface {
 
     static final String SALTYRTC_SUBPROTOCOL = "v1.saltyrtc.org";
-    static final short SALTYRTC_WS_CONNECT_TIMEOUT = 10000;
+    static final short SALTYRTC_WS_CONNECT_TIMEOUT = 3000;
+    static final short SALTYRTC_WS_CONNECT_ATTEMPTS_MAX = 20;
+    static final boolean SALTYRTC_WS_CONNECT_LINEAR_BACKOFF = true;
     static final long SALTYRTC_WS_PING_INTERVAL = 20000;
     static final short SALTYRTC_ADDR_UNKNOWN = 0x00;
     static final short SALTYRTC_ADDR_SERVER = 0x00;
@@ -93,6 +95,9 @@ public abstract class Signaling implements SignalingInterface {
     private final SSLContext sslContext;
     private WebSocket ws;
     private int pingInterval;
+    private int wsConnectTimeoutInitial;
+    private int wsConnectAttemptsMax;
+    private boolean wsConnectLinearBackoff;
     private int wsConnectTimeout;
     private int wsConnectAttempt = 0;
 
@@ -131,6 +136,8 @@ public abstract class Signaling implements SignalingInterface {
     public Signaling(SaltyRTC salty, String host, int port,
                      @Nullable SSLContext sslContext,
                      @Nullable Integer wsConnectTimeout,
+                     @Nullable Integer wsConnectAttemptsMax,
+                     @Nullable Boolean wsConnectLinearBackoff,
                      @NonNull KeyStore permanentKey,
                      @Nullable byte[] peerTrustedKey,
                      @Nullable byte[] expectedServerKey,
@@ -141,7 +148,9 @@ public abstract class Signaling implements SignalingInterface {
         this.host = host;
         this.port = port;
         this.sslContext = sslContext;
-        this.wsConnectTimeout = wsConnectTimeout == null ? SALTYRTC_WS_CONNECT_TIMEOUT : wsConnectTimeout;
+        this.wsConnectTimeoutInitial = wsConnectTimeout == null ? SALTYRTC_WS_CONNECT_TIMEOUT : wsConnectTimeout;
+        this.wsConnectAttemptsMax = wsConnectAttemptsMax == null ? SALTYRTC_WS_CONNECT_ATTEMPTS_MAX : wsConnectAttemptsMax;
+        this.wsConnectLinearBackoff = wsConnectLinearBackoff == null ? SALTYRTC_WS_CONNECT_LINEAR_BACKOFF : wsConnectLinearBackoff;
         this.permanentKey = permanentKey;
         this.peerTrustedKey = peerTrustedKey;
         this.expectedServerKey = expectedServerKey;
@@ -315,9 +324,22 @@ public abstract class Signaling implements SignalingInterface {
             @SuppressWarnings("UnqualifiedMethodAccess")
             public void onConnectError(WebSocket websocket, WebSocketException ex) throws Exception {
                 getLogger().error("Could not connect to websocket (" + ex.getError().toString() + "): " + ex.getMessage());
-                if (Signaling.this.wsConnectAttempt == 1) {
-                    getLogger().info("Retrying to reconnect once...");
+                if (Signaling.this.wsConnectAttemptsMax <= 0 || Signaling.this.wsConnectAttempt < Signaling.this.wsConnectAttemptsMax) {
+                    if (Signaling.this.wsConnectLinearBackoff) {
+                        Signaling.this.wsConnectTimeout += Signaling.this.wsConnectTimeoutInitial;
+                    }
                     Signaling.this.wsConnectAttempt += 1;
+
+                    // Log retry attempt
+                    String retryConstraint;
+                    if (Signaling.this.wsConnectAttemptsMax <= 0) {
+                        retryConstraint = "infinitely";
+                    } else {
+                        retryConstraint = Signaling.this.wsConnectAttempt + "/" + Signaling.this.wsConnectAttemptsMax;
+                    }
+                    getLogger().info("Retrying to reconnect (" + retryConstraint + ")...");
+
+                    // Retry WS connection
                     Signaling.this.setState(SignalingState.WS_CONNECTING);
                     Signaling.this.ws.recreate(Signaling.this.wsConnectTimeout).connectAsynchronously();
                 } else {
@@ -488,6 +510,9 @@ public abstract class Signaling implements SignalingInterface {
             }
         };
 
+        // Reset timeout
+        this.wsConnectTimeout = this.wsConnectTimeoutInitial;
+
         // Create WebSocket client instance
         this.ws = new WebSocketFactory()
                 .setConnectionTimeout(this.wsConnectTimeout)
@@ -503,7 +528,7 @@ public abstract class Signaling implements SignalingInterface {
      */
     private void connectWebsocket() {
         this.setState(SignalingState.WS_CONNECTING);
-        this.wsConnectAttempt = 1;
+        this.wsConnectAttempt = 0;
         this.ws.connectAsynchronously();
     }
 

--- a/src/main/java/org/saltyrtc/client/signaling/Signaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/Signaling.java
@@ -94,10 +94,10 @@ public abstract class Signaling implements SignalingInterface {
     private final int port;
     private final SSLContext sslContext;
     private WebSocket ws;
-    private int pingInterval;
-    private int wsConnectTimeoutInitial;
-    private int wsConnectAttemptsMax;
-    private boolean wsConnectLinearBackoff;
+    final private int pingInterval;
+    final private int wsConnectTimeoutInitial;
+    final private int wsConnectAttemptsMax;
+    final private boolean wsConnectLinearBackoff;
     private int wsConnectTimeout;
     private int wsConnectAttempt = 0;
 
@@ -332,7 +332,7 @@ public abstract class Signaling implements SignalingInterface {
                     Signaling.this.wsConnectAttempt += 1;
 
                     // Log retry attempt
-                    String retryConstraint;
+                    final String retryConstraint;
                     if (Signaling.this.wsConnectAttemptsMax <= 0) {
                         retryConstraint = "infinitely";
                     } else {

--- a/src/main/java/org/saltyrtc/client/signaling/Signaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/Signaling.java
@@ -325,6 +325,7 @@ public abstract class Signaling implements SignalingInterface {
             public void onConnectError(WebSocket websocket, WebSocketException ex) throws Exception {
                 getLogger().error("Could not connect to websocket (" + ex.getError().toString() + "): " + ex.getMessage());
                 if (Signaling.this.wsConnectAttemptsMax <= 0 || Signaling.this.wsConnectAttempt < Signaling.this.wsConnectAttemptsMax) {
+                    // Increase #attempts (and timeout if needed)
                     if (Signaling.this.wsConnectLinearBackoff) {
                         Signaling.this.wsConnectTimeout += Signaling.this.wsConnectTimeoutInitial;
                     }
@@ -528,7 +529,7 @@ public abstract class Signaling implements SignalingInterface {
      */
     private void connectWebsocket() {
         this.setState(SignalingState.WS_CONNECTING);
-        this.wsConnectAttempt = 0;
+        this.wsConnectAttempt = 1;
         this.ws.connectAsynchronously();
     }
 


### PR DESCRIPTION
* Change the default WS connect timeout to 3s, retrying 20 times with linear backoff (last try has a 60s timeout)
* Make maximum connection retry attempts before giving up configurable
* Add possibility to apply linear backoff for connection attempts
* Add tests for configuration of these parameters

@dbrgn ~~Couldn't fully test these changes, so it's probably wise if you test them in a real world scenario.~~ Nevermind, tested with the SaltyRTC Demo, seems to work fine and should fix the eduroam problem for Threema Web.