### PR TITLE
Remove gradle witness

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,7 @@ current directory, run the tests:
 
 ## Security
 
-### Dependency Verification
-
-This project uses [gradle-witness](https://github.com/WhisperSystems/gradle-witness)
-to make sure that you always get the exact same versions of your dependencies.
+### Release Checksums
 
 These are the SHA256 hashes for the published releases of this project:
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath files('libs/gradle-witness.jar')
     }
 }
 
@@ -17,7 +16,6 @@ plugins {
     id 'com.jfrog.bintray' version '1.7'
 }
 
-apply plugin: 'witness'
 apply plugin: 'maven'
 
 def app_version = '0.11.1'
@@ -49,20 +47,6 @@ dependencies {
     // Test dependencies
     testCompile 'org.slf4j:slf4j-simple:1.7.21'
     testCompile 'junit:junit:4.12'
-}
-
-dependencyVerification {
-    verify = [
-            'org.slf4j:slf4j-api:1d5aeb6bd98b0fdd151269eae941c05f6468a791ea0f1e68d8e7fe518af3e7df',
-            'org.json:json:bf51c9013128cb15201225e51476f60ad9116813729040655a238d2829aef8b8',
-            'org.msgpack:msgpack-core:0d7058c6ffeefbb47a4c80ceba0526931b39944291ebd134cac84882aa515721',
-            'org.msgpack:jackson-dataformat-msgpack:387eb22a21f21a3797665d1f721be0a255eed80be2281c27b59dccc7d10817c7',
-            'com.neovisionaries:nv-websocket-client:1abdf67bcdacff34210a4d914b47836021097d28dbbceb4d559c73e1054b83a4',
-            'com.fasterxml.jackson.core:jackson-databind:215022eed86bde62e8ff5e9b04297a6a7a896df89c80576aa2291e5e1142a94b',
-            'com.fasterxml.jackson.core:jackson-annotations:f775d20b6ad1ef122f453b2d7aeebb009523f7cdf89a674fe2f303221c95696b',
-            'com.fasterxml.jackson.core:jackson-core:526ab629da103bf2c93e72bd541d7c34e498182460c56d5f48b03dbac91b1df9',
-            'org.saltyrtc.chunked-dc:chunked-dc:32e2b3f90ba64057e43acc49c3d7c33f1cc5492bfadebcfdfcf2de603b415948',
-    ]
 }
 
 test {


### PR DESCRIPTION
It makes it impossible to use version ranges for dependencies.

Dependency pinning should be done at application level, not at library level.