### PR TITLE
Fix protocol errors triggered by new clients after task state

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-all.zip

--- a/src/main/java/org/saltyrtc/client/signaling/InitiatorSignaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/InitiatorSignaling.java
@@ -357,8 +357,11 @@ public class InitiatorSignaling extends Signaling {
      * Store a new responder.
      */
     private void processNewResponder(short responderId) throws ConnectionException, SignalingException {
-        // Drop responder if it's already known
-        this.responders.remove(responderId);
+        // Discard previous responder (if any)
+        if (this.responders.remove(responderId) != null) {
+            this.getLogger().warn("Previous responder discarded (server should have sent " +
+                "'disconnected' message): " + responderId);
+        }
 
         // Create responder instance
         final Responder responder;

--- a/src/main/java/org/saltyrtc/client/signaling/ResponderSignaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/ResponderSignaling.java
@@ -420,6 +420,22 @@ public class ResponderSignaling extends Signaling {
     }
 
     /**
+     * Close when a new initiator has connected.
+     *
+     * Note: This deviates from the intention of the specification to allow
+     *       for more than one connection towards an initiator over the same
+     *       WebSocket connection.
+     */
+    void onUnhandledSignalingServerMessage(@NonNull final Message msg) throws ConnectionException, SignalingException {
+        if (msg instanceof NewInitiator) {
+            this.getLogger().debug("Received new-initiator message after peer handshake completed, closing");
+            this.resetConnection(CloseCode.CLOSING_NORMAL);
+        } else {
+            this.getLogger().warn("Unexpected server message type: " + msg.getType());
+        }
+    }
+
+    /**
      * A new initiator replaces the old one.
      */
     private void handleNewInitiator(@SuppressWarnings("unused") NewInitiator msg) throws SignalingException, ConnectionException {

--- a/src/main/java/org/saltyrtc/client/signaling/Signaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/Signaling.java
@@ -346,11 +346,14 @@ public abstract class Signaling implements SignalingInterface {
             @SuppressWarnings("UnqualifiedMethodAccess")
             public synchronized void onBinaryMessage(WebSocket websocket, byte[] binary) {
                 getLogger().debug("New binary message (" + binary.length + " bytes)");
-
-                // Update state if necessary
-                if (getState() == SignalingState.WS_CONNECTING) {
-                    getLogger().info("WebSocket connection open");
-                    setState(SignalingState.SERVER_HANDSHAKE);
+                switch (Signaling.this.getState()) {
+                    case WS_CONNECTING:
+                        getLogger().info("WebSocket connection open");
+                        Signaling.this.setState(SignalingState.SERVER_HANDSHAKE);
+                        break;
+                    case CLOSED:
+                        getLogger().debug("Ignoring message in state " + Signaling.this.getState());
+                        return;
                 }
 
                 SignalingChannelNonce nonce = null;

--- a/src/test/java/org/saltyrtc/client/tests/integration/ConnectionTest.java
+++ b/src/test/java/org/saltyrtc/client/tests/integration/ConnectionTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import org.saltyrtc.client.SaltyRTC;
 import org.saltyrtc.client.SaltyRTCBuilder;
 import org.saltyrtc.client.SaltyRTCServerInfo;
+import org.saltyrtc.client.annotations.NonNull;
 import org.saltyrtc.client.crypto.CryptoProvider;
 import org.saltyrtc.client.tests.LazysodiumCryptoProvider;
 import org.saltyrtc.client.exceptions.ConnectionException;
@@ -51,6 +52,68 @@ public class ConnectionTest {
     private SaltyRTC responder;
     private Map<String, Boolean> eventsCalled;
     private CryptoProvider cryptoProvider;
+
+    static void await(@NonNull final CountDownLatch latch) throws InterruptedException {
+        await(latch, 5);
+    }
+
+    static void await(@NonNull final CountDownLatch latch, long timeoutSeconds) throws InterruptedException {
+        if (!latch.await(timeoutSeconds, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Timed out after " + timeoutSeconds + " seconds");
+        }
+    }
+
+    static void awaitState(@NonNull final SignalingState state, @NonNull final SaltyRTC... peers)
+        throws ConnectionException, InterruptedException {
+        assert peers.length > 0;
+
+        // Latches to wait for a specific state
+        final CountDownLatch done = new CountDownLatch(peers.length);
+
+        // Register event on all peers
+        for (@NonNull final SaltyRTC peer: peers) {
+            // Check current state
+            if (peer.getSignalingState() == state) {
+                done.countDown();
+                continue;
+            }
+
+            // Register state change event
+            peer.events.signalingStateChanged.register(event -> {
+                if (event.getState() == state) {
+                    done.countDown();
+                    return true;
+                }
+                return false;
+            });
+        }
+
+        // Wait for the state to fire on all peers
+        await(done);
+
+    }
+
+    static void connect(@NonNull final SignalingState state, @NonNull final SaltyRTC... peers)
+        throws ConnectionException, InterruptedException {
+        assert peers.length > 0;
+
+        // Connect all peers
+        for (@NonNull final SaltyRTC peer: peers) {
+            peer.connect();
+        }
+
+        // Wait until connected
+        awaitState(state, peers);
+    }
+
+    static void disconnect(@NonNull final SaltyRTC... peers) {
+        assert peers.length > 0;
+
+        // Disconnect all peers
+        for (@NonNull final SaltyRTC peer: peers) {
+            peer.disconnect();
+        }
+    }
 
     @Before
     public void setUp() throws Exception {
@@ -117,37 +180,23 @@ public class ConnectionTest {
         });
     }
 
+    @After
+    public void tearDown() {
+        disconnect(initiator, responder);
+    }
+
     @Test
     public void testHandshakeInitiatorFirst() throws Exception {
         // Signaling state should still be NEW
         assertEquals(SignalingState.NEW, initiator.getSignalingState());
         assertEquals(SignalingState.NEW, responder.getSignalingState());
 
-        // Latches to test connection state
-        final CountDownLatch connectedPeers = new CountDownLatch(2);
+        // Connect initiator, then the responder
+        connect(SignalingState.PEER_HANDSHAKE, initiator);
+        connect(SignalingState.TASK, responder);
+        awaitState(SignalingState.TASK, initiator);
 
-        // Register onConnect handler
-        initiator.events.signalingStateChanged.register(event -> {
-            if (event.getState() == SignalingState.TASK) {
-                connectedPeers.countDown();
-            }
-            return false;
-        });
-        responder.events.signalingStateChanged.register(event -> {
-            if (event.getState() == SignalingState.TASK) {
-                connectedPeers.countDown();
-            }
-            return false;
-        });
-
-        // Connect server
-        initiator.connect();
-        Thread.sleep(1000);
-        responder.connect();
-
-        // Wait for full handshake
-        final boolean bothConnected = connectedPeers.await(4, TimeUnit.SECONDS);
-        assertTrue(bothConnected);
+        // Ensure no error has been fired
         assertFalse(eventsCalled.get("initiatorError"));
         assertFalse(eventsCalled.get("responderError"));
 
@@ -156,11 +205,9 @@ public class ConnectionTest {
         assertEquals(SignalingState.TASK, responder.getSignalingState());
 
         // Disconnect
-        initiator.disconnect();
-        responder.disconnect();
+        disconnect(initiator, responder);
 
         // Await close events
-        Thread.sleep(300);
         assertTrue(eventsCalled.get("initiatorClosed"));
         assertTrue(eventsCalled.get("responderClosed"));
         assertFalse(eventsCalled.get("initiatorError"));
@@ -177,31 +224,12 @@ public class ConnectionTest {
         assertEquals(SignalingState.NEW, initiator.getSignalingState());
         assertEquals(SignalingState.NEW, responder.getSignalingState());
 
-        // Latches to test connection state
-        final CountDownLatch connectedPeers = new CountDownLatch(2);
+        // Connect responder, then the initiator
+        connect(SignalingState.PEER_HANDSHAKE, responder);
+        connect(SignalingState.TASK, initiator);
+        awaitState(SignalingState.TASK, responder);
 
-        // Register onConnect handler
-        responder.events.signalingStateChanged.register(event -> {
-            if (event.getState() == SignalingState.TASK) {
-                connectedPeers.countDown();
-            }
-            return false;
-        });
-        initiator.events.signalingStateChanged.register(event -> {
-            if (event.getState() == SignalingState.TASK) {
-                connectedPeers.countDown();
-            }
-            return false;
-        });
-
-        // Connect server
-        responder.connect();
-        Thread.sleep(1000);
-        initiator.connect();
-
-        // Wait for full handshake
-        final boolean bothConnected = connectedPeers.await(4, TimeUnit.SECONDS);
-        assertTrue(bothConnected);
+        // Ensure no error has been fired
         assertFalse(eventsCalled.get("responderError"));
         assertFalse(eventsCalled.get("initiatorError"));
 
@@ -210,11 +238,9 @@ public class ConnectionTest {
         assertEquals(SignalingState.TASK, initiator.getSignalingState());
 
         // Disconnect
-        responder.disconnect();
-        initiator.disconnect();
+        disconnect(initiator, responder);
 
         // Await close events
-        Thread.sleep(300);
         assertTrue(eventsCalled.get("responderClosed"));
         assertTrue(eventsCalled.get("initiatorClosed"));
         assertFalse(eventsCalled.get("responderError"));
@@ -227,42 +253,21 @@ public class ConnectionTest {
 
     @Test
     public void testConnectionSpeed() throws Exception {
-        // Max 1s for handshake
         final int MAX_DURATION = 1000;
-
-        // Latches to test connection state
-        final CountDownLatch connectedPeers = new CountDownLatch(2);
-        initiator.events.signalingStateChanged.register(event -> {
-            if (event.getState() == SignalingState.TASK) {
-                connectedPeers.countDown();
-            }
-            return false;
-        });
-        responder.events.signalingStateChanged.register(event -> {
-            if (event.getState() == SignalingState.TASK) {
-                connectedPeers.countDown();
-            }
-            return false;
-        });
-
-        // Connect server
         final long startTime = System.nanoTime();
-        initiator.connect();
-        responder.connect();
 
         // Wait for full handshake
-        final boolean bothConnected = connectedPeers.await(2 * MAX_DURATION, TimeUnit.MILLISECONDS);
+        connect(SignalingState.TASK, initiator, responder);
+
+        // Calculate duration
         final long endTime = System.nanoTime();
-        assertTrue(bothConnected);
         assertFalse(eventsCalled.get("responderError"));
         assertFalse(eventsCalled.get("initiatorError"));
         long durationMs = (endTime - startTime) / 1000 / 1000;
         System.out.println("Full handshake took " + durationMs + " milliseconds");
 
         // Disconnect
-        responder.disconnect();
-        initiator.disconnect();
-
+        disconnect(initiator, responder);
         assertTrue("Duration time (" + durationMs + "ms) should be less than " + MAX_DURATION + "ms",
                    durationMs < MAX_DURATION);
     }
@@ -288,40 +293,17 @@ public class ConnectionTest {
         assertEquals(SignalingState.NEW, trustingInitiator.getSignalingState());
         assertEquals(SignalingState.NEW, trustingResponder.getSignalingState());
 
-        // Latches to test connection state
-        final CountDownLatch connectedPeers = new CountDownLatch(2);
-        trustingInitiator.events.signalingStateChanged.register(event -> {
-            if (event.getState() == SignalingState.TASK) {
-                connectedPeers.countDown();
-            }
-            return false;
-        });
-        trustingResponder.events.signalingStateChanged.register(event -> {
-            if (event.getState() == SignalingState.TASK) {
-                connectedPeers.countDown();
-            }
-            return false;
-        });
-
-        // Connect server
-        trustingInitiator.connect();
-        Thread.sleep(1000);
-        trustingResponder.connect();
-
-        // Wait for full handshake
-        final boolean bothConnected = connectedPeers.await(4, TimeUnit.SECONDS);
-        assertTrue(bothConnected);
+        // Connect initiator, then the responder
+        connect(SignalingState.PEER_HANDSHAKE, trustingInitiator);
+        connect(SignalingState.TASK, trustingResponder);
+        awaitState(SignalingState.TASK, trustingInitiator);
 
         // Signaling state should be TASK
         assertEquals(SignalingState.TASK, trustingInitiator.getSignalingState());
         assertEquals(SignalingState.TASK, trustingResponder.getSignalingState());
 
         // Disconnect
-        trustingInitiator.disconnect();
-        trustingResponder.disconnect();
-
-        // Await close events
-        Thread.sleep(300);
+        disconnect(trustingInitiator, trustingResponder);
 
         // Signaling state should be CLOSED
         assertEquals(SignalingState.CLOSED, trustingInitiator.getSignalingState());
@@ -349,42 +331,17 @@ public class ConnectionTest {
         assertEquals(SignalingState.NEW, trustingInitiator.getSignalingState());
         assertEquals(SignalingState.NEW, trustingResponder.getSignalingState());
 
-        // Latches to test connection state
-        final CountDownLatch connectedPeers = new CountDownLatch(2);
-
-        // Register onConnect handler
-        trustingInitiator.events.signalingStateChanged.register(event -> {
-            if (event.getState() == SignalingState.TASK) {
-                connectedPeers.countDown();
-            }
-            return false;
-        });
-        trustingResponder.events.signalingStateChanged.register(event -> {
-            if (event.getState() == SignalingState.TASK) {
-                connectedPeers.countDown();
-            }
-            return false;
-        });
-
-        // Connect server
-        trustingResponder.connect();
-        Thread.sleep(1000);
-        trustingInitiator.connect();
-
-        // Wait for full handshake
-        final boolean bothConnected = connectedPeers.await(4, TimeUnit.SECONDS);
-        assertTrue(bothConnected);
+        // Connect responder, then the initiator
+        connect(SignalingState.PEER_HANDSHAKE, trustingResponder);
+        connect(SignalingState.TASK, trustingInitiator);
+        awaitState(SignalingState.TASK, trustingResponder);
 
         // Signaling state should be TASK
         assertEquals(SignalingState.TASK, trustingInitiator.getSignalingState());
         assertEquals(SignalingState.TASK, trustingResponder.getSignalingState());
 
         // Disconnect
-        trustingInitiator.disconnect();
-        trustingResponder.disconnect();
-
-        // Await close events
-        Thread.sleep(300);
+        disconnect(trustingInitiator, trustingResponder);
 
         // Signaling state should be CLOSED
         assertEquals(SignalingState.CLOSED, trustingInitiator.getSignalingState());
@@ -415,31 +372,10 @@ public class ConnectionTest {
         assertEquals(SignalingState.NEW, initiator.getSignalingState());
         assertEquals(SignalingState.NEW, responder.getSignalingState());
 
-        // Latches to test connection state
-        final CountDownLatch connectedPeers = new CountDownLatch(2);
-
-        // Register onConnect handler
-        initiator.events.signalingStateChanged.register(event -> {
-            if (event.getState() == SignalingState.TASK) {
-                connectedPeers.countDown();
-            }
-            return false;
-        });
-        responder.events.signalingStateChanged.register(event -> {
-            if (event.getState() == SignalingState.TASK) {
-                connectedPeers.countDown();
-            }
-            return false;
-        });
-
-        // Connect server
-        responder.connect();
-        Thread.sleep(1000);
-        initiator.connect();
-
-        // Wait for full handshake
-        final boolean bothConnected = connectedPeers.await(4, TimeUnit.SECONDS);
-        assertTrue(bothConnected);
+        // Connect responder, then the initiator
+        connect(SignalingState.PEER_HANDSHAKE, responder);
+        connect(SignalingState.TASK, initiator);
+        awaitState(SignalingState.TASK, responder);
 
         // Signaling state should be TASK
         assertEquals(SignalingState.TASK, initiator.getSignalingState());
@@ -450,7 +386,7 @@ public class ConnectionTest {
         assertTrue(responder.getTask() instanceof PingPongTask);
 
         // Wait for ping-pong-messages
-        Thread.sleep(500);
+        Thread.sleep(100);
 
         // Check whether ping-pong happened
         assertTrue(responderTask.sentPong);
@@ -459,11 +395,7 @@ public class ConnectionTest {
         assertFalse(initiatorTask.sentPong);
 
         // Disconnect
-        initiator.disconnect();
-        responder.disconnect();
-
-        // Await close events
-        Thread.sleep(300);
+        disconnect(initiator, responder);
 
         // Signaling state should be CLOSED
         assertEquals(SignalingState.CLOSED, initiator.getSignalingState());
@@ -479,21 +411,8 @@ public class ConnectionTest {
             .usingTasks(new Task[]{ new DummyTask() })
             .asInitiator();
 
-        // Look for signaling changes
-        final CountDownLatch closed = new CountDownLatch(1);
-        initiator.events.signalingStateChanged.register(
-            event -> {
-                if (event.getState() == SignalingState.PEER_HANDSHAKE) {
-                    closed.countDown();
-                }
-                return false;
-            }
-        );
-
-        // Connect server and wait for peer handshake
-        initiator.connect();
-        final boolean success = closed.await(2, TimeUnit.SECONDS);
-        assertTrue(success);
+        // Connect and wait for peer handshake
+        connect(SignalingState.PEER_HANDSHAKE, initiator);
     }
 
     @Test
@@ -506,7 +425,7 @@ public class ConnectionTest {
             .asInitiator();
 
         // Look for signaling changes
-        final CountDownLatch closed = new CountDownLatch(1);
+        final CountDownLatch errored = new CountDownLatch(1);
         initiator.events.signalingStateChanged.register(event -> {
             if (event.getState() == SignalingState.PEER_HANDSHAKE) {
                 fail("Server handshake succeeded even though server key was wrong");
@@ -515,16 +434,16 @@ public class ConnectionTest {
         });
         initiator.events.close.register(event -> {
             if (event.getReason() == CloseCode.PROTOCOL_ERROR) {
-                closed.countDown();
+                errored.countDown();
             } else {
                 fail("Signaling was closed without a protocol error");
             }
             return false;
         });
 
-        // Connect server and wait for connection closing
+        // Connect and wait for protocol error
         initiator.connect();
-        final boolean success = closed.await(2, TimeUnit.SECONDS);
+        final boolean success = errored.await(2, TimeUnit.SECONDS);
         assertTrue(success);
     }
 
@@ -538,19 +457,8 @@ public class ConnectionTest {
             .usingTasks(new Task[]{ new DummyTask() })
             .asResponder();
 
-        // Look for signaling changes
-        final CountDownLatch closed = new CountDownLatch(1);
-        responder.events.signalingStateChanged.register(event -> {
-            if (event.getState() == SignalingState.PEER_HANDSHAKE) {
-                closed.countDown();
-            }
-            return false;
-        });
-
-        // Connect server and wait for peer handshake
-        responder.connect();
-        final boolean success = closed.await(2, TimeUnit.SECONDS);
-        assertTrue(success);
+        // Connect and wait for peer handshake
+        connect(SignalingState.PEER_HANDSHAKE, responder);
     }
 
     @Test
@@ -564,7 +472,7 @@ public class ConnectionTest {
             .asResponder();
 
         // Look for signaling changes
-        final CountDownLatch closed = new CountDownLatch(1);
+        final CountDownLatch errored = new CountDownLatch(1);
         responder.events.signalingStateChanged.register(event -> {
             if (event.getState() == SignalingState.PEER_HANDSHAKE) {
                 fail("Server handshake succeeded even though server key was wrong");
@@ -573,92 +481,17 @@ public class ConnectionTest {
         });
         responder.events.close.register(event -> {
             if (event.getReason() == CloseCode.PROTOCOL_ERROR) {
-                closed.countDown();
+                errored.countDown();
             } else {
                 fail("Signaling was closed without a protocol error");
             }
             return false;
         });
 
-        // Connect server and wait for connection closing
+        // Connect and wait for protocol error
         responder.connect();
-        final boolean success = closed.await(2, TimeUnit.SECONDS);
+        final boolean success = errored.await(2, TimeUnit.SECONDS);
         assertTrue(success);
-    }
-
-    @Test
-    public void testApplicationMessagePingPong() throws Exception {
-        // Create peers
-        final SSLContext sslContext = SSLContextHelper.getSSLContext();
-        final SaltyRTC initiator = new SaltyRTCBuilder(this.cryptoProvider)
-            .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT, sslContext)
-            .withKeyStore(new KeyStore(this.cryptoProvider))
-            .usingTasks(new Task[]{ new DummyTask() })
-            .asInitiator();
-        final SaltyRTC responder = new SaltyRTCBuilder(this.cryptoProvider)
-            .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT, sslContext)
-            .withKeyStore(new KeyStore(this.cryptoProvider))
-            .usingTasks(new Task[]{ new DummyTask() })
-            .initiatorInfo(initiator.getPublicPermanentKey(), initiator.getAuthToken())
-            .asResponder();
-
-        // Latches to test connection state
-        final CountDownLatch connectedPeers = new CountDownLatch(2);
-        final CountDownLatch messagesReceived = new CountDownLatch(2);
-
-        // Register onConnect handler
-        initiator.events.signalingStateChanged.register(event -> {
-            if (event.getState() == SignalingState.TASK) {
-                connectedPeers.countDown();
-            }
-            return false;
-        });
-        responder.events.signalingStateChanged.register(event -> {
-            if (event.getState() == SignalingState.TASK) {
-                connectedPeers.countDown();
-            }
-            return false;
-        });
-
-        // Connect server
-        responder.connect();
-        Thread.sleep(1000);
-        initiator.connect();
-
-        // Wait for full handshake
-        final boolean bothConnected = connectedPeers.await(4, TimeUnit.SECONDS);
-        assertTrue(bothConnected);
-
-        // Signaling state should be TASK
-        assertEquals(SignalingState.TASK, initiator.getSignalingState());
-        assertEquals(SignalingState.TASK, responder.getSignalingState());
-
-        // Add application message handlers
-        initiator.events.applicationData.register(event -> {
-            messagesReceived.countDown();
-            return false;
-        });
-        responder.events.applicationData.register(event -> {
-            messagesReceived.countDown();
-            Assert.assertEquals(event.getData(), "ping");
-            try {
-                responder.sendApplicationMessage("pong");
-            } catch (ConnectionException | InvalidStateException e) {
-                e.printStackTrace();
-            }
-            return false;
-        });
-
-        // Send ping message
-        initiator.sendApplicationMessage("ping");
-
-        // Wait for ping-pong-messages
-        final boolean bothReceived = messagesReceived.await(2, TimeUnit.SECONDS);
-        assertTrue(bothReceived);
-
-        // Disconnect
-        initiator.disconnect();
-        responder.disconnect();
     }
 
     @Test
@@ -687,25 +520,55 @@ public class ConnectionTest {
             .usingTasks(new Task[]{ new DummyTask() })
             .asResponder();
 
-        // Look for signaling changes
-        final CountDownLatch closed = new CountDownLatch(1);
-        responder.events.signalingStateChanged.register(event -> {
-            if (event.getState() == SignalingState.PEER_HANDSHAKE) {
-                closed.countDown();
+        // Connect and wait for peer handshake
+        connect(SignalingState.PEER_HANDSHAKE, responder);
+    }
+
+    @Test
+    public void testApplicationMessagePingPong() throws Exception {
+        // Create peers
+        final SSLContext sslContext = SSLContextHelper.getSSLContext();
+        final SaltyRTC initiator = new SaltyRTCBuilder(this.cryptoProvider)
+            .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT, sslContext)
+            .withKeyStore(new KeyStore(this.cryptoProvider))
+            .usingTasks(new Task[]{ new DummyTask() })
+            .asInitiator();
+        final SaltyRTC responder = new SaltyRTCBuilder(this.cryptoProvider)
+            .connectTo(Config.SALTYRTC_HOST, Config.SALTYRTC_PORT, sslContext)
+            .withKeyStore(new KeyStore(this.cryptoProvider))
+            .usingTasks(new Task[]{ new DummyTask() })
+            .initiatorInfo(initiator.getPublicPermanentKey(), initiator.getAuthToken())
+            .asResponder();
+        final CountDownLatch messagesReceived = new CountDownLatch(2);
+
+        // Connect both
+        connect(SignalingState.TASK, initiator, responder);
+
+        // Add application message handlers
+        initiator.events.applicationData.register(event -> {
+            messagesReceived.countDown();
+            return false;
+        });
+        responder.events.applicationData.register(event -> {
+            Assert.assertEquals(event.getData(), "ping");
+            try {
+                responder.sendApplicationMessage("pong");
+            } catch (ConnectionException | InvalidStateException e) {
+                e.printStackTrace();
             }
+            messagesReceived.countDown();
             return false;
         });
 
-        // Connect server and wait for peer handshake
-        responder.connect();
-        final boolean success = closed.await(2, TimeUnit.SECONDS);
-        assertTrue(success);
-    }
+        // Send ping message
+        initiator.sendApplicationMessage("ping");
 
-    @After
-    public void tearDown() {
-        initiator.disconnect();
-        responder.disconnect();
+        // Wait for ping-pong-messages
+        final boolean bothReceived = messagesReceived.await(2, TimeUnit.SECONDS);
+        assertTrue(bothReceived);
+
+        // Disconnect
+        disconnect(initiator, responder);
     }
 
 }


### PR DESCRIPTION
With this PR we handle `new-initiator` and `new-responder` after a peer handshake properly (somewhat). Resolves #102.

An initiator now simply drops new responders when it has already completed the handshake with another responder.

A responder now closes the connection when a new initiator connects after it has already completed a handshake with a previous initiator.

Note that this deviates from the intention of the specification to allow for more than one connection towards a responder over the same WebSocket connection. But resolving this would be far from trivial.

Also resolves #103.