### PR TITLE
Add dual stack mode setting to builder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     compile 'org.msgpack:jackson-dataformat-msgpack:0.8.+'
 
     // Dependency: WebSockets
-    compile 'com.neovisionaries:nv-websocket-client:2.+'
+    compile 'com.neovisionaries:nv-websocket-client:2.9+'
 
     // Dependency: Binary chunking
     compile 'org.saltyrtc.chunked-dc:chunked-dc:1.+'

--- a/src/main/java/org/saltyrtc/client/SaltyRTC.java
+++ b/src/main/java/org/saltyrtc/client/SaltyRTC.java
@@ -48,13 +48,15 @@ public class SaltyRTC {
     SaltyRTC(KeyStore permanentKey, String host, int port,
              @Nullable SSLContext sslContext,
              @NonNull CryptoProvider cryptoProvider,
+             @NonNull SaltyRTCBuilder.DualStackMode wsDualStackMode,
              @Nullable Integer wsConnectTimeout,
              @Nullable Integer wsConnectAttemptsMax,
              @Nullable Boolean wsConnectLinearBackoff,
              @Nullable byte[] serverKey,
              Task[] tasks, int pingInterval) {
         this.signaling = new InitiatorSignaling(
-            this, host, port, sslContext, cryptoProvider, wsConnectTimeout, wsConnectAttemptsMax, wsConnectLinearBackoff,
+            this, host, port, sslContext, cryptoProvider,
+            wsDualStackMode, wsConnectTimeout, wsConnectAttemptsMax, wsConnectLinearBackoff,
             permanentKey, null, serverKey, tasks, pingInterval);
     }
 
@@ -63,6 +65,7 @@ public class SaltyRTC {
     SaltyRTC(KeyStore permanentKey, String host, int port,
              @Nullable SSLContext sslContext,
              @NonNull CryptoProvider cryptoProvider,
+             @NonNull SaltyRTCBuilder.DualStackMode wsDualStackMode,
              @Nullable Integer wsConnectTimeout,
              @Nullable Integer wsConnectAttemptsMax,
              @Nullable Boolean wsConnectLinearBackoff,
@@ -70,7 +73,8 @@ public class SaltyRTC {
              @Nullable byte[] serverKey, Task[] tasks, int pingInterval)
              throws InvalidKeyException {
         this.signaling = new ResponderSignaling(
-            this, host, port, sslContext, cryptoProvider, wsConnectTimeout, wsConnectAttemptsMax, wsConnectLinearBackoff,
+            this, host, port, sslContext, cryptoProvider,
+            wsDualStackMode, wsConnectTimeout, wsConnectAttemptsMax, wsConnectLinearBackoff,
             permanentKey, initiatorPublicKey, authToken, null, serverKey, tasks, pingInterval);
     }
 
@@ -79,6 +83,7 @@ public class SaltyRTC {
     SaltyRTC(KeyStore permanentKey, String host, int port,
              @Nullable SSLContext sslContext,
              @NonNull CryptoProvider cryptoProvider,
+             @NonNull SaltyRTCBuilder.DualStackMode wsDualStackMode,
              @Nullable Integer wsConnectTimeout,
              @Nullable Integer wsConnectAttemptsMax,
              @Nullable Boolean wsConnectLinearBackoff,
@@ -88,12 +93,14 @@ public class SaltyRTC {
         switch (role) {
             case Initiator:
                 this.signaling = new InitiatorSignaling(
-                    this, host, port, sslContext, cryptoProvider, wsConnectTimeout, wsConnectAttemptsMax, wsConnectLinearBackoff,
+                    this, host, port, sslContext, cryptoProvider,
+                    wsDualStackMode, wsConnectTimeout, wsConnectAttemptsMax, wsConnectLinearBackoff,
                     permanentKey, peerTrustedKey, serverKey, tasks, pingInterval);
                 break;
             case Responder:
                 this.signaling = new ResponderSignaling(
-                    this, host, port, sslContext, cryptoProvider, wsConnectTimeout, wsConnectAttemptsMax, wsConnectLinearBackoff,
+                    this, host, port, sslContext, cryptoProvider,
+                    wsDualStackMode, wsConnectTimeout, wsConnectAttemptsMax, wsConnectLinearBackoff,
                     permanentKey, null, null, peerTrustedKey, serverKey, tasks, pingInterval);
                 break;
             default:

--- a/src/main/java/org/saltyrtc/client/SaltyRTCBuilder.java
+++ b/src/main/java/org/saltyrtc/client/SaltyRTCBuilder.java
@@ -23,6 +23,27 @@ import javax.net.ssl.SSLContext;
  * Builder class to construct a SaltyRTC instance.
  */
 public class SaltyRTCBuilder {
+    /**
+     * The dual stack mode defines which IP address families will be used to
+     * establish a SaltyRTC WebSocket connection.
+     */
+    public enum DualStackMode {
+        /**
+         * Try both IPv4 and IPv6 to establish a connection. Used by default and
+         * should generally be preferred.
+         */
+        BOTH,
+
+        /**
+         * Only use IPv4 to establish a connection.
+         */
+        IPV4_ONLY,
+
+        /**
+         * Only use IPv6 to establish a connection.
+         */
+        IPV6_ONLY,
+    }
 
     private boolean hasKeyStore = false;
     private boolean hasConnectionInfo = false;
@@ -34,6 +55,7 @@ public class SaltyRTCBuilder {
     private KeyStore keyStore;
     private String host;
     private Integer port;
+    private DualStackMode wsDualStackMode = DualStackMode.BOTH;
     private Integer wsConnectTimeout;
     private Integer wsConnectAttemptsMax;
     private Boolean wsConnectLinearBackoff;
@@ -249,6 +271,16 @@ public class SaltyRTCBuilder {
     }
 
     /**
+     * Override the default WebSocket dual stack mode (which is to try both IPv4 and IPv6).
+     *
+     * @param dualStackMode The preferred dual stack mode to be used for connections.
+     */
+    public SaltyRTCBuilder withWebSocketDualStackMode(DualStackMode dualStackMode) {
+        this.wsDualStackMode = dualStackMode;
+        return this;
+    }
+
+    /**
      * Set initiator connection info transferred via a secure data channel.
      *
      * @param initiatorPublicKey The public key of the initiator.
@@ -313,13 +345,15 @@ public class SaltyRTCBuilder {
 
         if (this.hasTrustedPeerKey) {
             return new SaltyRTC(
-                this.keyStore, this.host, this.port, this.sslContext, this.cryptoProvider, this.wsConnectTimeout, this.wsConnectAttemptsMax,
-                this.wsConnectLinearBackoff, this.peerTrustedKey, this.serverKey,
+                this.keyStore, this.host, this.port, this.sslContext, this.cryptoProvider,
+                this.wsDualStackMode, this.wsConnectTimeout, this.wsConnectAttemptsMax, this.wsConnectLinearBackoff,
+                this.peerTrustedKey, this.serverKey,
                 this.tasks, this.pingInterval, SignalingRole.Initiator);
         } else {
             return new SaltyRTC(
-                this.keyStore, this.host, this.port, this.sslContext, this.cryptoProvider, this.wsConnectTimeout, this.wsConnectAttemptsMax,
-                this.wsConnectLinearBackoff, this.serverKey, this.tasks, this.pingInterval);
+                this.keyStore, this.host, this.port, this.sslContext, this.cryptoProvider,
+                this.wsDualStackMode, this.wsConnectTimeout, this.wsConnectAttemptsMax, this.wsConnectLinearBackoff,
+                this.serverKey, this.tasks, this.pingInterval);
         }
     }
 
@@ -339,16 +373,18 @@ public class SaltyRTCBuilder {
             if (this.serverInfo != null) {
                 this.processServerInfo(this.serverInfo, this.peerTrustedKey);
             }
-            return new SaltyRTC(this.keyStore, this.host, this.port, this.sslContext, this.cryptoProvider, this.wsConnectTimeout,
-                this.wsConnectAttemptsMax, this.wsConnectLinearBackoff, this.peerTrustedKey, this.serverKey,
+            return new SaltyRTC(this.keyStore, this.host, this.port, this.sslContext, this.cryptoProvider,
+                this.wsDualStackMode, this.wsConnectTimeout, this.wsConnectAttemptsMax, this.wsConnectLinearBackoff,
+                this.peerTrustedKey, this.serverKey,
                 this.tasks, this.pingInterval, SignalingRole.Responder);
         } else {
             this.requireInitiatorInfo();
             if (this.serverInfo != null) {
                 this.processServerInfo(this.serverInfo, this.initiatorPublicKey);
             }
-            return new SaltyRTC(this.keyStore, this.host, this.port, this.sslContext, this.cryptoProvider, this.wsConnectTimeout,
-                this.wsConnectAttemptsMax, this.wsConnectLinearBackoff, this.initiatorPublicKey, this.authToken,
+            return new SaltyRTC(this.keyStore, this.host, this.port, this.sslContext, this.cryptoProvider,
+                this.wsDualStackMode, this.wsConnectTimeout, this.wsConnectAttemptsMax, this.wsConnectLinearBackoff,
+                this.initiatorPublicKey, this.authToken,
                 this.serverKey, this.tasks, this.pingInterval);
         }
     }

--- a/src/main/java/org/saltyrtc/client/signaling/InitiatorSignaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/InitiatorSignaling.java
@@ -9,6 +9,7 @@
 package org.saltyrtc.client.signaling;
 
 import org.saltyrtc.client.SaltyRTC;
+import org.saltyrtc.client.SaltyRTCBuilder;
 import org.saltyrtc.client.annotations.NonNull;
 import org.saltyrtc.client.annotations.Nullable;
 import org.saltyrtc.client.cookie.Cookie;
@@ -60,6 +61,7 @@ public class InitiatorSignaling extends Signaling {
     public InitiatorSignaling(SaltyRTC saltyRTC, String host, int port,
                               @Nullable SSLContext sslContext,
                               @NonNull CryptoProvider cryptoProvider,
+                              @NonNull SaltyRTCBuilder.DualStackMode wsDualStackMode,
                               @Nullable Integer wsConnectTimeout,
                               @Nullable Integer wsConnectAttemptsMax,
                               @Nullable Boolean wsConnectLinearBackoff,
@@ -68,7 +70,8 @@ public class InitiatorSignaling extends Signaling {
                               @Nullable byte[] expectedServerKey,
                               @NonNull Task[] tasks,
                               int pingInterval) {
-        super(saltyRTC, host, port, sslContext, cryptoProvider, wsConnectTimeout, wsConnectAttemptsMax, wsConnectLinearBackoff,
+        super(saltyRTC, host, port, sslContext, cryptoProvider,
+              wsDualStackMode, wsConnectTimeout, wsConnectAttemptsMax, wsConnectLinearBackoff,
               permanentKey, responderTrustedKey, expectedServerKey, SignalingRole.Initiator, tasks, pingInterval);
         if (responderTrustedKey == null) {
             this.authToken = new AuthToken(cryptoProvider);

--- a/src/main/java/org/saltyrtc/client/signaling/ResponderSignaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/ResponderSignaling.java
@@ -9,6 +9,7 @@
 package org.saltyrtc.client.signaling;
 
 import org.saltyrtc.client.SaltyRTC;
+import org.saltyrtc.client.SaltyRTCBuilder;
 import org.saltyrtc.client.annotations.NonNull;
 import org.saltyrtc.client.annotations.Nullable;
 import org.saltyrtc.client.cookie.Cookie;
@@ -58,6 +59,7 @@ public class ResponderSignaling extends Signaling {
     public ResponderSignaling(SaltyRTC saltyRTC, String host, int port,
                               @Nullable SSLContext sslContext,
                               @NonNull CryptoProvider cryptoProvider,
+                              @NonNull SaltyRTCBuilder.DualStackMode wsDualStackMode,
                               @Nullable Integer wsConnectTimeout,
                               @Nullable Integer wsConnectAttemptsMax,
                               @Nullable Boolean wsConnectLinearBackoff,
@@ -68,7 +70,8 @@ public class ResponderSignaling extends Signaling {
                               @NonNull Task[] tasks,
                               int pingInterval)
                               throws InvalidKeyException {
-        super(saltyRTC, host, port, sslContext, cryptoProvider, wsConnectTimeout, wsConnectAttemptsMax, wsConnectLinearBackoff,
+        super(saltyRTC, host, port, sslContext, cryptoProvider,
+              wsDualStackMode, wsConnectTimeout, wsConnectAttemptsMax, wsConnectLinearBackoff,
               permanentKey, initiatorTrustedKey, expectedServerKey, SignalingRole.Responder, tasks, pingInterval);
         if (initiatorTrustedKey != null) {
             if (initiatorPublicKey != null || authToken != null) {

--- a/src/test/java/org/saltyrtc/client/tests/signaling/SignalingTest.java
+++ b/src/test/java/org/saltyrtc/client/tests/signaling/SignalingTest.java
@@ -35,12 +35,14 @@ public class SignalingTest {
     public void testWsPath() throws Exception {
         // Create signaling instances for initiator and responder
         final InitiatorSignaling initiator = new InitiatorSignaling(
-                null, Config.SALTYRTC_HOST, Config.SALTYRTC_PORT, null, new LazysodiumCryptoProvider(), null, null, null,
+                null, Config.SALTYRTC_HOST, Config.SALTYRTC_PORT, null, new LazysodiumCryptoProvider(),
+                SaltyRTCBuilder.DualStackMode.BOTH, null, null, null,
                 new KeyStore(this.cryptoProvider), null, null,
                 new Task[] { new DummyTask() },
                 0);
         final ResponderSignaling responder = new ResponderSignaling(
-                null, Config.SALTYRTC_HOST, Config.SALTYRTC_PORT, null, new LazysodiumCryptoProvider(), null, null, null,
+                null, Config.SALTYRTC_HOST, Config.SALTYRTC_PORT, null, new LazysodiumCryptoProvider(),
+                SaltyRTCBuilder.DualStackMode.BOTH, null, null, null,
                 new KeyStore(this.cryptoProvider), initiator.getPublicPermanentKey(), initiator.getAuthToken(), null, null,
                 new Task[] { new DummyTask() },
                 0);
@@ -150,5 +152,4 @@ public class SignalingTest {
         boolean linearBackoff = (boolean) fLinearBackoff.get(sig);
         assertFalse(linearBackoff);
     }
-
 }


### PR DESCRIPTION
Depends on https://github.com/TakahikoKawasaki/nv-websocket-client/pull/183

Had to copy the enum since we want to maintain independence regarding the WebSocket implementation. (Would be even better to move the WebSocket library outside of this library.)