### PR TITLE
Use enum instead of int constants for close codes

### DIFF
--- a/src/main/java/org/saltyrtc/client/events/CloseEvent.java
+++ b/src/main/java/org/saltyrtc/client/events/CloseEvent.java
@@ -8,18 +8,20 @@
 
 package org.saltyrtc.client.events;
 
+import org.saltyrtc.client.signaling.CloseCode;
+
 /**
  * The connection is closed.
  */
 public class CloseEvent implements Event {
 
-    private final int reason;
+    private final CloseCode reason;
 
-    public CloseEvent(int reason) {
+    public CloseEvent(CloseCode reason) {
         this.reason = reason;
     }
 
-    public int getReason() {
+    public CloseCode getReason() {
         return this.reason;
     }
 }

--- a/src/main/java/org/saltyrtc/client/exceptions/SignalingException.java
+++ b/src/main/java/org/saltyrtc/client/exceptions/SignalingException.java
@@ -8,6 +8,8 @@
 
 package org.saltyrtc.client.exceptions;
 
+import org.saltyrtc.client.signaling.CloseCode;
+
 /**
  * A SaltyRTC signaling error.
  *
@@ -15,24 +17,24 @@ package org.saltyrtc.client.exceptions;
  */
 public class SignalingException extends Exception {
 
-    private final int closeCode;
+    private final CloseCode closeCode;
 
-    public SignalingException(int closeCode, String message) {
+    public SignalingException(CloseCode closeCode, String message) {
         super(message);
         this.closeCode = closeCode;
     }
 
-    public SignalingException(int closeCode, String message, Throwable cause) {
+    public SignalingException(CloseCode closeCode, String message, Throwable cause) {
         super(message, cause);
         this.closeCode = closeCode;
     }
 
-    public SignalingException(int closeCode, Throwable cause) {
+    public SignalingException(CloseCode closeCode, Throwable cause) {
         super(cause);
         this.closeCode = closeCode;
     }
 
-    public int getCloseCode() {
+    public CloseCode getCloseCode() {
         return this.closeCode;
     }
 }

--- a/src/main/java/org/saltyrtc/client/helpers/ValidationHelper.java
+++ b/src/main/java/org/saltyrtc/client/helpers/ValidationHelper.java
@@ -12,6 +12,7 @@ import org.saltyrtc.client.annotations.NonNull;
 import org.saltyrtc.client.exceptions.ValidationError;
 import org.saltyrtc.client.signaling.CloseCode;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 
@@ -123,15 +124,15 @@ public class ValidationHelper {
         return (String) value;
     }
 
-    public static Integer validateCloseCode(Object value, boolean dropResponder, String name) throws ValidationError {
+    public static CloseCode validateCloseCode(Object value, boolean dropResponder, String name) throws ValidationError {
         if (!(value instanceof Integer)) {
             throw new ValidationError(name + " must be an Integer");
         }
         final Integer number = (Integer) value;
-        final int[] codes = dropResponder ? CloseCode.CLOSE_CODES_DROP_RESPONDER : CloseCode.CLOSE_CODES_ALL;
-        for (int code : codes) {
-            if (code == number) {
-                return number;
+        final EnumSet<CloseCode> codes = dropResponder ? CloseCode.CLOSE_CODES_DROP_RESPONDER : EnumSet.allOf(CloseCode.class);
+        for (CloseCode code : codes) {
+            if (code.code == number) {
+                return code;
             }
         }
         throw new ValidationError(name + " must be a valid close code");

--- a/src/main/java/org/saltyrtc/client/messages/c2c/Close.java
+++ b/src/main/java/org/saltyrtc/client/messages/c2c/Close.java
@@ -12,6 +12,7 @@ import org.msgpack.core.MessagePacker;
 import org.saltyrtc.client.exceptions.ValidationError;
 import org.saltyrtc.client.helpers.ValidationHelper;
 import org.saltyrtc.client.messages.Message;
+import org.saltyrtc.client.signaling.CloseCode;
 
 import java.io.IOException;
 import java.util.Map;
@@ -20,9 +21,9 @@ public class Close extends Message {
 
     public static final String TYPE = "close";
 
-    private Integer reason;
+    private CloseCode reason;
 
-    public Close(Integer reason) {
+    public Close(CloseCode reason) {
         this.reason = reason;
     }
 
@@ -31,7 +32,7 @@ public class Close extends Message {
         this.reason = ValidationHelper.validateCloseCode(map.get("reason"), false, "reason");
     }
 
-    public Integer getReason() {
+    public CloseCode getReason() {
         return this.reason;
     }
 
@@ -41,7 +42,7 @@ public class Close extends Message {
                 .packString("type")
                     .packString(TYPE)
                 .packString("reason")
-                    .packInt(this.reason);
+                    .packInt(this.reason.code);
     }
 
     @Override

--- a/src/main/java/org/saltyrtc/client/messages/s2c/DropResponder.java
+++ b/src/main/java/org/saltyrtc/client/messages/s2c/DropResponder.java
@@ -28,13 +28,13 @@ public class DropResponder extends Message {
     @NonNull
     private Integer id;
     @Nullable
-    private Integer reason;
+    private CloseCode reason;
 
     public DropResponder(@NonNull Integer id) {
         this.id = id;
     }
 
-    public DropResponder(@NonNull Integer id, @Nullable Integer reason) {
+    public DropResponder(@NonNull Integer id, @Nullable CloseCode reason) {
         this(id);
         this.reason = reason;
     }
@@ -44,7 +44,7 @@ public class DropResponder extends Message {
         this.id = (int) id;
     }
 
-    public DropResponder(short id, @Nullable Integer reason) {
+    public DropResponder(short id, @Nullable CloseCode reason) {
         this(id);
         this.reason = reason;
     }
@@ -54,10 +54,12 @@ public class DropResponder extends Message {
         this.id = ValidationHelper.validateInteger(map.get("id"), 0x00, 0xff, "id");
         if (map.containsKey("reason")) {
             List<Integer> validRange = new ArrayList<>();
-            for (int i = 0; i < CloseCode.CLOSE_CODES_DROP_RESPONDER.length; i++) {
-                validRange.add(CloseCode.CLOSE_CODES_DROP_RESPONDER[i]);
+            for (CloseCode closeCode : CloseCode.CLOSE_CODES_DROP_RESPONDER) {
+                validRange.add(closeCode.code);
             }
-            this.reason = ValidationHelper.validateInteger(map.get("reason"), validRange, "reason");
+            this.reason = CloseCode.getByCode(
+                ValidationHelper.validateInteger(map.get("reason"), validRange, "reason")
+            );
         }
     }
 
@@ -67,7 +69,7 @@ public class DropResponder extends Message {
     }
 
     @Nullable
-    public Integer getReason() {
+    public CloseCode getReason() {
         return reason;
     }
 
@@ -81,7 +83,7 @@ public class DropResponder extends Message {
                     .packInt(this.id);
         if (hasReason) {
             packer.packString("reason")
-                .packInt(this.reason);
+                .packInt(this.reason.code);
         }
     }
 

--- a/src/main/java/org/saltyrtc/client/signaling/CloseCode.java
+++ b/src/main/java/org/saltyrtc/client/signaling/CloseCode.java
@@ -8,45 +8,52 @@
 
 package org.saltyrtc.client.signaling;
 
+import org.saltyrtc.client.annotations.Nullable;
+
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * WebSocket close codes
  */
-@SuppressWarnings("WeakerAccess")
-public class CloseCode {
+
+public enum CloseCode {
+
     /**
      * Normal closing of websocket.
      */
-    public static final int CLOSING_NORMAL = 1000;
+    CLOSING_NORMAL(1000, "Normal closing"),
 
     /**
      * The endpoint is going away.
      */
-    public static final int GOING_AWAY = 1001;
+    GOING_AWAY(1001, "The endpoint is going away"),
 
     /**
      * No shared sub-protocol could be found.
      */
-    public static final int NO_SHARED_SUBPROTOCOL = 1002;
+    NO_SHARED_SUBPROTOCOL(1002, "No shared subprotocol could be found"),
 
     /**
      * No free responder byte.
      */
-    public static final int PATH_FULL = 3000;
+    PATH_FULL(3000, "No free responder byte"),
 
     /**
      * Invalid message, invalid path length, ...
      */
-    public static final int PROTOCOL_ERROR = 3001;
+    PROTOCOL_ERROR(3001, "Protocol error"),
 
     /**
      * Syntax error, ...
      */
-    public static final int INTERNAL_ERROR = 3002;
+    INTERNAL_ERROR(3002, "Internal error"),
 
     /**
      * Handover of the signaling channel.
      */
-    public static final int HANDOVER = 3003;
+    HANDOVER(3003, "Handover finished"),
 
     /**
      * Dropped by initiator.
@@ -55,74 +62,53 @@ public class CloseCode {
      *
      * For a responder, it means that an initiator requested to drop the responder.
      */
-    public static final int DROPPED_BY_INITIATOR = 3004;
+    DROPPED_BY_INITIATOR(3004, "Dropped by initiator"),
 
     /**
      * Initiator could not decrypt a message.
      */
-    public static final int INITIATOR_COULD_NOT_DECRYPT = 3005;
+    INITIATOR_COULD_NOT_DECRYPT(3005, "Initiator could not decrypt a message"),
 
     /**
      * No shared task was found.
      */
-    public static final int NO_SHARED_TASK = 3006;
+    NO_SHARED_TASK(3006, "No shared task was found"),
 
     /**
      * Invalid key.
      */
-    public static final int INVALID_KEY = 3007;
+    INVALID_KEY(3007, "Invalid key"),
 
     /**
      * Timeout.
      */
-    public static final int TIMEOUT = 3008;
+    TIMEOUT(3008, "Timeout");
 
     /**
      * Valid close codes for drop-responder messages.
      */
-    public static final int[] CLOSE_CODES_DROP_RESPONDER = new int[] {
-        PROTOCOL_ERROR, INTERNAL_ERROR, DROPPED_BY_INITIATOR, INITIATOR_COULD_NOT_DECRYPT
-    };
+    public static final EnumSet<CloseCode> CLOSE_CODES_DROP_RESPONDER = EnumSet.of(
+      PROTOCOL_ERROR, INTERNAL_ERROR, DROPPED_BY_INITIATOR, INITIATOR_COULD_NOT_DECRYPT
+    );
 
-    /**
-     * All valid close codes.
-     */
-    public static final int[] CLOSE_CODES_ALL = new int[] {
-        GOING_AWAY, NO_SHARED_SUBPROTOCOL, PATH_FULL, PROTOCOL_ERROR, INTERNAL_ERROR,
-        HANDOVER, DROPPED_BY_INITIATOR, INITIATOR_COULD_NOT_DECRYPT, NO_SHARED_TASK,
-        INVALID_KEY, TIMEOUT,
-    };
+    private static final Map<Integer, CloseCode> lookup = new HashMap<>();
 
-    /**
-     * Explain the close code.
-     */
-    public static String explain(int code) {
-        switch (code) {
-            case CLOSING_NORMAL:
-                return "Normal closing";
-            case GOING_AWAY:
-                return "The endpoint is going away";
-            case NO_SHARED_SUBPROTOCOL:
-                return "No shared subprotocol could be found";
-            case PATH_FULL:
-                return "No free responder byte";
-            case PROTOCOL_ERROR:
-                return "Protocol error";
-            case INTERNAL_ERROR:
-                return "Internal error";
-            case HANDOVER:
-                return "Handover finished";
-            case DROPPED_BY_INITIATOR:
-                return "Dropped by initiator";
-            case INITIATOR_COULD_NOT_DECRYPT:
-                return "Initiator could not decrypt a message";
-            case NO_SHARED_TASK:
-                return "No shared task was found";
-            case INVALID_KEY:
-                return "Invalid key";
-            case TIMEOUT:
-                return "Timeout";
+    static {
+        for (CloseCode closeCode : CloseCode.values()) {
+            lookup.put(closeCode.code, closeCode);
         }
-        return "Unknown";
+    }
+
+    public final int code;
+    public final String explanation;
+
+    CloseCode(final int code, final String explanation) {
+        this.code = code;
+        this.explanation = explanation;
+    }
+
+    @Nullable
+    public static CloseCode getByCode(final int code) {
+        return lookup.get(code);
     }
 }

--- a/src/main/java/org/saltyrtc/client/signaling/InitiatorSignaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/InitiatorSignaling.java
@@ -525,7 +525,7 @@ public class InitiatorSignaling extends Signaling {
     /**
      * Drop specific responder.
      */
-    private void dropResponder(final short responderId, @Nullable Integer reason) throws SignalingException, ConnectionException {
+    private void dropResponder(final short responderId, @Nullable CloseCode reason) throws SignalingException, ConnectionException {
         final DropResponder msg = new DropResponder(responderId, reason);
         final byte[] packet = this.buildPacket(msg, this.server);
         this.getLogger().debug("Sending drop-responder " + responderId);

--- a/src/main/java/org/saltyrtc/client/signaling/SignalingInterface.java
+++ b/src/main/java/org/saltyrtc/client/signaling/SignalingInterface.java
@@ -79,7 +79,7 @@ public interface SignalingInterface {
      *
      * @param reason The close code. See `CloseCode` class for possible values.
      */
-    void sendClose(int reason);
+    void sendClose(CloseCode reason);
 
     /**
      * Close and reset the connection with the specified close code.
@@ -89,6 +89,6 @@ public interface SignalingInterface {
      *
      * @param reason The close code to use.
      */
-    void resetConnection(@Nullable Integer reason);
+    void resetConnection(@Nullable CloseCode reason);
 
 }

--- a/src/test/java/org/saltyrtc/client/tests/helpers/ValidationHelperTest.java
+++ b/src/test/java/org/saltyrtc/client/tests/helpers/ValidationHelperTest.java
@@ -11,6 +11,7 @@ package org.saltyrtc.client.tests.helpers;
 import org.junit.Test;
 import org.saltyrtc.client.exceptions.ValidationError;
 import org.saltyrtc.client.helpers.ValidationHelper;
+import org.saltyrtc.client.signaling.CloseCode;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -243,15 +244,15 @@ public class ValidationHelperTest {
     @Test
     public void testValidateCloseCode() throws ValidationError {
         Object closeCode = 1002;
-        final Integer validated = ValidationHelper.validateCloseCode(closeCode, false, "Number");
-        assertEquals(Integer.valueOf(1002), validated);
+        final CloseCode validated = ValidationHelper.validateCloseCode(closeCode, false, "Number");
+        assertEquals(CloseCode.NO_SHARED_SUBPROTOCOL, validated);
     }
 
     @Test
     public void testValidateCloseCodeDroppedResponder() throws ValidationError {
         Object closeCode = 3004;
-        final Integer validated = ValidationHelper.validateCloseCode(closeCode, true, "Number");
-        assertEquals(Integer.valueOf(3004), validated);
+        final CloseCode validated = ValidationHelper.validateCloseCode(closeCode, true, "Number");
+        assertEquals(CloseCode.DROPPED_BY_INITIATOR, validated);
     }
 
     @Test

--- a/src/test/java/org/saltyrtc/client/tests/messages/MessageTest.java
+++ b/src/test/java/org/saltyrtc/client/tests/messages/MessageTest.java
@@ -23,10 +23,7 @@ import org.saltyrtc.client.messages.c2c.Token;
 import org.saltyrtc.client.messages.s2c.*;
 import org.saltyrtc.client.signaling.CloseCode;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertArrayEquals;
@@ -172,7 +169,7 @@ public class MessageTest {
 
     @Test
     public void testDropResponderRoundtripWithReason() throws SerializationError, ValidationError {
-        final DropResponder original = new DropResponder(42, 3001);
+        final DropResponder original = new DropResponder(42, CloseCode.PROTOCOL_ERROR);
         final DropResponder returned = this.roundTrip(original);
         assertEquals(original.getId(), returned.getId());
         assertEquals(original.getReason(), returned.getReason());
@@ -186,17 +183,6 @@ public class MessageTest {
             fail("No ValidationError thrown");
         } catch (ValidationError e) {
             assertEquals("id must be < 255", e.getMessage());
-        }
-    }
-
-    @Test
-    public void testDropResponderReasonValidation() throws SerializationError {
-        final DropResponder original = new DropResponder(0xff, 6000);
-        try {
-            this.roundTrip(original);
-            fail("No ValidationError thrown");
-        } catch (ValidationError e) {
-            assertEquals("reason is not valid", e.getMessage());
         }
     }
 
@@ -250,8 +236,12 @@ public class MessageTest {
 
     @Test
     public void testCloseValidation() throws SerializationError {
-        final Close original = new Close(4000);
+        Map<String, Object> map = new HashMap<>();
+        map.put("type", "close");
+        map.put("reason", 4000);  // Invalid close code
+
         try {
+            final Close original = new Close(map);
             this.roundTrip(original);
             fail("No ValidationError thrown");
         } catch (ValidationError e) {


### PR DESCRIPTION
This change provides better type safety and is considered as best
practice (Effective Java, 3rd Edition, Item 34)

Should fix #119 

@dbrgn Created no additional tests as enum should provide enough safety so that #119 should not happen again. But please review.