### PR TITLE
Synchronize on Signaling class

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,6 @@ Maven:
 Documentation can be found at
 [https://saltyrtc.github.io/saltyrtc-client-java/](https://saltyrtc.github.io/saltyrtc-client-java/).
 
-Plase note that instances of this library are not considered thread-safe. Thus, an application
-using more than one thread needs to take care of synchronisation itself.
-
 ## Manual Testing
 
 To try a development version of the library, you can build a local version to

--- a/src/main/java/org/saltyrtc/client/SaltyRTC.java
+++ b/src/main/java/org/saltyrtc/client/SaltyRTC.java
@@ -38,7 +38,7 @@ public class SaltyRTC {
     private boolean debug = false;
 
     // Reference to signaling class
-    private Signaling signaling;
+    private final Signaling signaling;
 
     // Event registry
     public final SaltyRTC.Events events = new SaltyRTC.Events();
@@ -102,22 +102,30 @@ public class SaltyRTC {
     }
 
     public KeyStore getKeyStore() {
-        return this.signaling.getKeyStore();
+        synchronized (this.signaling) {
+            return this.signaling.getKeyStore();
+        }
     }
 
     public byte[] getPublicPermanentKey() {
-        return this.signaling.getPublicPermanentKey();
+        synchronized (this.signaling) {
+            return this.signaling.getPublicPermanentKey();
+        }
     }
 
     public byte[] getAuthToken() {
-        return this.signaling.getAuthToken();
+        synchronized (this.signaling) {
+            return this.signaling.getAuthToken();
+        }
     }
 
     /**
      * Return the current signaling state.
      */
     public SignalingState getSignalingState() {
-        return this.signaling.getState();
+        synchronized (this.signaling) {
+            return this.signaling.getState();
+        }
     }
 
     /**
@@ -125,7 +133,9 @@ public class SaltyRTC {
      */
     @Nullable
     public Task getTask() {
-        return this.signaling.getTask();
+        synchronized (this.signaling) {
+            return this.signaling.getTask();
+        }
     }
 
     /**
@@ -137,7 +147,9 @@ public class SaltyRTC {
      * @throws ConnectionException if setting up the WebSocket connection fails.
      */
     public void connect() throws ConnectionException {
-        this.signaling.connect();
+        synchronized (this.signaling) {
+            this.signaling.connect();
+        }
     }
 
     /**
@@ -147,11 +159,13 @@ public class SaltyRTC {
      * @throws InvalidStateException if the SaltyRTC instance is not currently in the TASK signaling state.
      */
     public void sendApplicationMessage(Object data) throws ConnectionException, InvalidStateException {
-        if (this.signaling.getState() != SignalingState.TASK) {
-            throw new InvalidStateException(
-                "Application messages can only be sent in TASK state, not in " + this.signaling.getState().name());
+        synchronized (this.signaling) {
+            if (this.signaling.getState() != SignalingState.TASK) {
+                throw new InvalidStateException(
+                    "Application messages can only be sent in TASK state, not in " + this.signaling.getState().name());
+            }
+            this.signaling.sendApplication(new Application(data));
         }
-        this.signaling.sendApplication(new Application(data));
     }
 
     /**
@@ -162,7 +176,9 @@ public class SaltyRTC {
      * this method again from within your `SignalingStateChangedEvent` event handlers, or deadlocks may occur!
      */
     public void disconnect() {
-        this.signaling.disconnect();
+        synchronized (this.signaling) {
+            this.signaling.disconnect();
+        }
     }
 
     /**

--- a/src/main/java/org/saltyrtc/client/signaling/InitiatorSignaling.java
+++ b/src/main/java/org/saltyrtc/client/signaling/InitiatorSignaling.java
@@ -78,7 +78,7 @@ public class InitiatorSignaling extends Signaling {
     /**
      * Handle signaling errors during peer handshake.
      */
-    synchronized void handlePeerHandshakeSignalingError(@NonNull SignalingException e, short source) {
+    void handlePeerHandshakeSignalingError(@NonNull SignalingException e, short source) {
         // Simply drop the responder
         Responder responder = this.responders.get(source);
         if (responder != null) {
@@ -544,7 +544,7 @@ public class InitiatorSignaling extends Signaling {
     }
 
     @Override
-    synchronized void handleSendError(short receiver) throws SignalingException {
+    void handleSendError(short receiver) throws SignalingException {
         // Validate receiver byte
         if (!this.isResponderId(receiver)) {
             throw new ProtocolException("Outgoing c2c messages must have been sent to a responder");


### PR DESCRIPTION
Before that change, the handler methods for the WebSocket library were
synchronized on the WebSocketAdapter while other methods in Signaling
class were synchronized on the class itself.

Also, the public SaltyRTC API is also synchronized on the Signaling
class now. With this change, the WebSocket library and the public API
are synchronized on the same class which should guarantee thread-safety.